### PR TITLE
Specify read chunksize for request body reader for streaming reason

### DIFF
--- a/lib/resty/http.lua
+++ b/lib/resty/http.lua
@@ -537,10 +537,11 @@ local function _read_trailers(res)
 end
 
 
-local function _send_body(sock, body)
+local function _send_body(sock, body, chunksize)
     if type(body) == 'function' then
+        chunksize = chunksize or 65536
         repeat
-            local chunk, err, partial = body()
+            local chunk, err, partial = body(chunksize)
 
             if chunk then
                 local ok, err = sock:send(chunk)


### PR DESCRIPTION
read chunksize take *65536* bytes by default.

this is useful for **streaming** POSTing a huge file, otherwise LuaVM may crash for OOM reason.