### PR TITLE
Make proxy_response fit for server-sent events.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Production ready.
 
 * HTTP 1.0 and 1.1
 * SSL
-* Streaming interface to the response body, for predictable memory usage
+* Streaming interface to the response body, for predictable memory usage or server-sent events
 * Alternative simple interface for singleshot requests without manual connection step
 * Chunked and non-chunked transfer encodings
 * Keepalive

--- a/lib/resty/http.lua
+++ b/lib/resty/http.lua
@@ -22,6 +22,7 @@ local ngx_log = ngx.log
 local ngx_DEBUG = ngx.DEBUG
 local ngx_ERR = ngx.ERR
 local ngx_var = ngx.var
+local ngx_flush = ngx.flush
 local ngx_print = ngx.print
 local ngx_header = ngx.header
 local co_yield = coroutine.yield
@@ -1009,6 +1010,13 @@ function _M.proxy_response(_, response, chunksize)
             if not res then
                 ngx_log(ngx_ERR, err)
                 break
+            else
+              -- flush, e.g., for server-sent event use cases
+              local fres, ferr = ngx_flush()
+              if not fres then
+                 ngx_log(ngx_ERR, ferr)
+                 break
+              end
             end
         end
     until not chunk


### PR DESCRIPTION
## Desired streaming functionality - general discussion

A main feature of `lua-resty-http` is the ability to provide reverse proxy functionality in *streaming* mode.

I see two main uses why people would want to use a streaming reverse proxy (as opposed to the behavior one gets from [`ngx.req.read_body`](https://github.com/openresty/lua-nginx-module#ngxreqread_body) or [`lua_need_request_body`](https://github.com/openresty/lua-nginx-module#lua_need_request_body)):

* Conversation of `nginx` memory (when large responses are being served).
* Minimize delay: Send the information to the client as soon as it is available to the reverse proxy.

In my case, I need a reverse proxy that handles [server-sent events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events). So, my context demands the second of the above.

## Bug description

It does not work presently. Here is a description of the bug fixed by this pull request:

The request reaches the upstream main application, the application starts sending its events, but the response never reaches the client. Experimenting with `curl`, I did not even see as much as the response's HTTP response code, nor the headers.

## Bug analysis

It seems that the present code first fills a buffer (presumably 4k or 8k large or so) before the first byte is sent to the client. A chunked response is essentially un-chunked, or, more precisely, repacked into much larger chunks. In my case, event chunks are rather short, so the client will need to wait for a very long time before the process of sending the response to the client even starts. In my experiments, I never waited that long.

## Fix presented here

If that analysis is correct, calling `ngx.flush()` should help. And indeed, it did.

This pull request introduces the `ngx.flush()`  that fixes the problem to the `proxy_response` function and also adds a pertinent remark to the README.