### PR TITLE
Fixed: allow data of chunk to be sent to downstream before logging error for chunk receive

### DIFF
--- a/lib/resty/http.lua
+++ b/lib/resty/http.lua
@@ -1019,17 +1019,12 @@ function _M.proxy_response(_, response, chunksize)
     local reader = response.body_reader
     repeat
         local chunk, err = reader(chunksize)
+        if chunk then
+            _, err = ngx_print(chunk)
+        end
         if err then
             ngx_log(ngx_ERR, err)
             break
-        end
-
-        if chunk then
-            local res, err = ngx_print(chunk)
-            if not res then
-                ngx_log(ngx_ERR, err)
-                break
-            end
         end
     until not chunk
 end


### PR DESCRIPTION
This change ensures that we don't lose data when the connection is closed while a chunk is being received.

This can happen when an HTTP 1.0 server responds without a Content Length header and the openresty server is set to stream the response.

```
...
client:proxy_response(res, 65536)
```

A server that behaves like this is the simple Python 2 server showed below:

```
#!/usr/bin/env python

from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
import SocketServer
import json

current = {"hello": "world"}

class S(BaseHTTPRequestHandler):

    def do_GET(self):
        self.send_response(200)
        self.send_header('Foo-Bar', 'Baz')
        self.end_headers()
        global current
        self.wfile.write(json.dumps(current))

    def do_POST(self):
        if self.headers.getheader('transfer-encoding', None):
            self.send_error(501)
            return

        data = self.rfile.read(int(self.headers.getheader('content-length', 0)))
        print data
        global current
        current = json.loads(data)
        self.send_response(204)
        self.send_header('Connection', 'close')
        self.end_headers()
        self.wfile.flush()

def run(server_class=HTTPServer, handler_class=S, port=80):
    server_address = ('', port)
    httpd = server_class(server_address, handler_class)
    print 'Starting httpd...'
    httpd.serve_forever()

if __name__ == "__main__":
    from sys import argv

    if len(argv) == 2:
        run(port=int(argv[1]))
    else:
        run()
```