### PR TITLE
[discussion] pool ssl/tls connections - alternative 2

### DIFF
--- a/.luacov
+++ b/.luacov
@@ -1,4 +1,5 @@
 modules = {
     ["http"] = "lib/resty/http.lua",
     ["http_headers"] = "lib/resty/http_headers.lua",
+    ["http_connect"] = "lib/resty/http_connect.lua",
 }

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ export PATH := $(OPENRESTY_PREFIX)/nginx/sbin:$(PATH)
 PROVE=TEST_NGINX_NO_SHUFFLE=1 prove -I../test-nginx/lib -r $(TEST_FILE)
 
 # Keep in sync with .luacov, so that we show the right amount of output
-LUACOV_NUM_MODULES ?= 2
+LUACOV_NUM_MODULES ?= 3
 
 .PHONY: all test install
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Attempts to connect to the web server.
 
 ### all-in-one connect
 
-This version of connect uses the `aio_options` signature above. For the
+This version of connect uses the `aio_options_table` signature above. For the
 other signatures see the [TCP only connect](#tcp-only-connect) below.
 
 This version of `connect` will connect to the remote end while incorporating the

--- a/README.md
+++ b/README.md
@@ -305,7 +305,6 @@ The `params` table accepts the following fields:
 * `query` The query string, presented as either a literal string or Lua table..
 * `headers` A table of request headers.
 * `body` The request body as a string, or an iterator function (see [get_client_body_reader](#get_client_body_reader)).
-* `ssl_verify` Verify SSL cert matches hostname
 
 When the request is successful, `res` will contain the following fields:
 
@@ -323,8 +322,9 @@ When the request is successful, `res` will contain the following fields:
 
 The simple interface. Options supplied in the `params` table are the same as in the generic interface, and will override components found in the uri itself.
 
-There are 3 additional parameters for controlling keepalives:
+There are 4 additional parameters for controlling keepalives and ssl:
 
+* `ssl_verify` Verify the SSL cert matches the hostname
 * `keepalive` Set to `false` to disable keepalives and immediately close the connection.
 * `keepalive_timeout` The maximal idle timeout (ms). Defaults to `lua_socket_keepalive_timeout`.
 * `keepalive_pool` The maximum number of connections in the pool. Defaults to `lua_socket_pool_size`.

--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ The options table has the following fields:
   SSL/Proxy properties to make it safe to re-use. When in doubt, leave it blank!
 * `pool_size`: option as per [OpenResty docs](https://github.com/openresty/lua-nginx-module#tcpsockconnect)
 * `backlog`: option as per [OpenResty docs](https://github.com/openresty/lua-nginx-module#tcpsockconnect)
+* `proxy_opts`: sub-table, defaults to the global proxy options set.
 * `ssl`: sub-table. **NOTE**: ssl will be used when either `scheme == "https"`, or when `ssl` is truthy
     * `server_name`: option as per [OpenResty docs](https://github.com/openresty/lua-nginx-module#tcpsocksslhandshake)
     * `send_status_req`: option as per [OpenResty docs](https://github.com/openresty/lua-nginx-module#tcpsocksslhandshake)

--- a/README.md
+++ b/README.md
@@ -184,12 +184,10 @@ The options table has the following fields:
   SSL/Proxy properties to make it safe to re-use. When in doubt, leave it blank!
 * `pool_size`: option as per [OpenResty docs](https://github.com/openresty/lua-nginx-module#tcpsockconnect)
 * `backlog`: option as per [OpenResty docs](https://github.com/openresty/lua-nginx-module#tcpsockconnect)
-* `proxy_opts`: sub-table, defaults to the global proxy options set.
-* `ssl`: sub-table. **NOTE**: ssl will be used when either `scheme == "https"`, or when `ssl` is truthy
-    * `server_name`: option as per [OpenResty docs](https://github.com/openresty/lua-nginx-module#tcpsocksslhandshake)
-    * `send_status_req`: option as per [OpenResty docs](https://github.com/openresty/lua-nginx-module#tcpsocksslhandshake)
-    * `ssl_verify`: option as per [OpenResty docs](https://github.com/openresty/lua-nginx-module#tcpsocksslhandshake), except that it defaults to `true`.
-    * `ctx`: NOT supported
+* `proxy_opts`: sub-table, defaults to the global proxy options set, see [set_proxy_options](#set-proxy-options).
+* `ssl_verify`: option as per [OpenResty docs](https://github.com/openresty/lua-nginx-module#tcpsocksslhandshake), except that it defaults to `true`.
+* `ssl_server_name`: option as per [OpenResty docs](https://github.com/openresty/lua-nginx-module#tcpsocksslhandshake)
+* `ssl_send_status_req`: option as per [OpenResty docs](https://github.com/openresty/lua-nginx-module#tcpsocksslhandshake)
 
 
 ### TCP only connect
@@ -320,11 +318,12 @@ When the request is successful, `res` will contain the following fields:
 
 `syntax: res, err = httpc:request_uri(uri, params)`
 
-The simple interface. Options supplied in the `params` table are the same as in the generic interface, and will override components found in the uri itself.
+The simple interface. Options supplied in the `params` table are the combined parameters
+from the all-in-one connect interface, and the generic request interface. The parameters
+will override components found in the uri itself.
 
-There are 4 additional parameters for controlling keepalives and ssl:
+There are 3 additional parameters for controlling keepalives:
 
-* `ssl_verify` Verify the SSL cert matches the hostname
 * `keepalive` Set to `false` to disable keepalives and immediately close the connection.
 * `keepalive_timeout` The maximal idle timeout (ms). Defaults to `lua_socket_keepalive_timeout`.
 * `keepalive_pool` The maximum number of connections in the pool. Defaults to `lua_socket_pool_size`.

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ following activities:
 
 - TCP connect
 - SSL handshake
-- HTTP-proxy
+- HTTP-proxy (options to be set using [set_proxy_options](#set_proxy_options))
 
 Whilst doing this it will also create a distinct pool name that is safe to use
 with SSL and/or Proxy based connections.
@@ -188,11 +188,6 @@ The options table has the following fields:
     * `server_name`: option as per [OpenResty docs](https://github.com/openresty/lua-nginx-module#tcpsocksslhandshake)
     * `ssl_verify`: option as per [OpenResty docs](https://github.com/openresty/lua-nginx-module#tcpsocksslhandshake), except that it defaults to `true`.
     * `ctx`: NOT supported
-
-* `proxy`: sub-table. **NOTE**: a proxy will be used only if `proxy.uri` is provided
-    * `uri`: uri of the proxy to use, eg. `"http://myproxy.internal:123"`
-    * `authorization`: a "Proxy-Authorization" header value to be used
-    * `no_proxy`: comma separated string of domains bypassing proxy
 
 
 ### TCP only connect
@@ -270,10 +265,10 @@ Configure an http proxy to be used with this client instance. The `opts` is a ta
 * `http_proxy` - an URI to a proxy server to be used with http requests
 * `http_proxy_authorization` - a default `Proxy-Authorization` header value to be used with `http_proxy`, e.g. `Basic ZGVtbzp0ZXN0`, which will be overriden if the `Proxy-Authorization` request header is present.
 * `https_proxy` - an URI to a proxy server to be used with https requests
-* `https_proxy_authorization` - as `http_proxy_authorization` but for use with `https_proxy`.
+* `https_proxy_authorization` - as `http_proxy_authorization` but for use with `https_proxy` (since with https the authorisation is done when connecting, this one cannot be overridden by passing the `Proxy-Authorization` request header).
 * `no_proxy` - a comma separated list of hosts that should not be proxied.
 
-Note that proxy options are only applied when using the high-level `request_uri()` API.
+Note that proxy options are only applied when using the high-level `request_uri()` API, or when using the all-in-one connect.
 
 ## get_reused_times
 

--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ The options table has the following fields:
 * `backlog`: option as per [OpenResty docs](https://github.com/openresty/lua-nginx-module#tcpsockconnect)
 * `ssl`: sub-table. **NOTE**: ssl will be used when either `scheme == "https"`, or when `ssl` is truthy
     * `server_name`: option as per [OpenResty docs](https://github.com/openresty/lua-nginx-module#tcpsocksslhandshake)
+    * `send_status_req`: option as per [OpenResty docs](https://github.com/openresty/lua-nginx-module#tcpsocksslhandshake)
     * `ssl_verify`: option as per [OpenResty docs](https://github.com/openresty/lua-nginx-module#tcpsocksslhandshake), except that it defaults to `true`.
     * `ctx`: NOT supported
 

--- a/lib/resty/http.lua
+++ b/lib/resty/http.lua
@@ -876,12 +876,6 @@ function _M.request_uri(self, uri, params)
         params.query = params.query or query
     end
 
-    if params.scheme == "https" and params.ssl_verify == false then
-        -- backward compat; params.ssl_verify --> params.ssl.ssl_verify
-        params.ssl = params.ssl or {}
-        params.ssl.ssl_verify = params.ssl_verify
-    end
-
     do
         local proxy_auth = (params.headers or {})["Proxy-Authorization"]
         if proxy_auth and params.proxy_opts then

--- a/lib/resty/http.lua
+++ b/lib/resty/http.lua
@@ -1053,6 +1053,8 @@ end
 
 
 function _M.set_proxy_options(self, opts)
+    -- TODO: parse and cache these options, instead of parsing them
+    -- on each request over and over again (lru-cache on module level)
     self.proxy_opts = tbl_copy(opts) -- Take by value
 end
 

--- a/lib/resty/http.lua
+++ b/lib/resty/http.lua
@@ -206,6 +206,7 @@ function _M.tcp_only_connect(self, ...)
     end
 
     self.keepalive = true
+    self.ssl = false
 
     return sock:connect(...)
 end

--- a/lib/resty/http.lua
+++ b/lib/resty/http.lua
@@ -309,7 +309,7 @@ function _M.parse_uri(_, uri, query_in_path)
 end
 
 
-local function _format_request(params)
+local function _format_request(self, params)
     local version = params.version
     local headers = params.headers or {}
 
@@ -324,6 +324,7 @@ local function _format_request(params)
     local req = {
         str_upper(params.method),
         " ",
+        self.path_prefix or "",
         params.path,
         query,
         HTTP[version],
@@ -332,7 +333,7 @@ local function _format_request(params)
         true,
         true,
     }
-    local c = 6 -- req table index it's faster to do this inline vs table.insert
+    local c = 7 -- req table index it's faster to do this inline vs table.insert
 
     -- Append headers
     for key, values in pairs(headers) do
@@ -681,7 +682,7 @@ function _M.send_request(self, params)
     params.headers = headers
 
     -- Format and send request
-    local req = _format_request(params)
+    local req = _format_request(self, params)
     if DEBUG then ngx_log(ngx_DEBUG, "\n", req) end
     local bytes, err = sock:send(req)
 
@@ -911,9 +912,9 @@ function _M.request_uri(self, uri, params)
             -- to also include the scheme, host and port so that the final form
             -- in conformant to RFC 7230.
             if port == 80 then
-                params.path = scheme .. "://" .. host .. path
+                self.path_prefix = scheme .. "://" .. host .. path
             else
-                params.path = scheme .. "://" .. host .. ":" .. port .. path
+                self.path_prefix = scheme .. "://" .. host .. ":" .. port .. path
             end
 
             if self.proxy_opts.http_proxy_authorization then

--- a/lib/resty/http.lua
+++ b/lib/resty/http.lua
@@ -632,6 +632,9 @@ function _M.send_request(self, params)
         for k, v in pairs(params_headers) do
             headers[k] = v
         end
+        if not headers["Proxy-Authorization"] then
+            headers["Proxy-Authorization"] = self.http_proxy_auth
+        end
     end
 
     -- Ensure minimal headers are set

--- a/lib/resty/http_connect.lua
+++ b/lib/resty/http_connect.lua
@@ -218,6 +218,8 @@ local function connect(self, options)
     self.port = request_port
     self.keepalive = true
     self.ssl = ssl
+    -- set only for http, https has already been handled
+    self.http_proxy_auth = request_scheme ~= "https" and proxy_authorization or nil
 
     return true
 end

--- a/lib/resty/http_connect.lua
+++ b/lib/resty/http_connect.lua
@@ -6,7 +6,7 @@ local ngx_re_find = ngx.re.find
 A connection function that incorporates:
   - tcp connect
   - ssl handshake
-  - http proxy (options to be set using "set_proxy_options")
+  - http proxy
 Due to this it will be better at setting up a socket pool where connections can
 be kept alive.
 
@@ -27,6 +27,8 @@ client:connect {
         ssl_verify = true,  -- defaults to true
         ctx = nil,          -- NOT supported
     },
+
+    proxy_opts,             -- proxy opts, defaults to global proxy options
 }
 ]]
 local function connect(self, options)
@@ -76,7 +78,7 @@ local function connect(self, options)
 
     -- proxy related settings
     local proxy, proxy_uri, proxy_authorization, proxy_host, proxy_port
-    proxy = self.proxy_opts
+    proxy = options.proxy_opts or self.proxy_opts
 
     if proxy then
         if request_scheme == "https" then

--- a/lib/resty/http_connect.lua
+++ b/lib/resty/http_connect.lua
@@ -202,6 +202,7 @@ local function connect(self, options)
     self.host = host
     self.port = port
     self.keepalive = true
+    self.ssl = ssl
 
     return true
 end

--- a/lib/resty/http_connect.lua
+++ b/lib/resty/http_connect.lua
@@ -55,25 +55,16 @@ local function connect(self, options)
 
     -- ssl settings
     local ssl, ssl_server_name, ssl_verify, send_status_req
-    if request_scheme ~= "http" then
-        -- either https or unix domain socket
-        ssl = options.ssl
+    ssl = (request_scheme == "https") or (not not options.ssl)
+    if ssl then
+        ssl_verify = true -- default
         if type(options.ssl) == "table" then
-            ssl_server_name = ssl.server_name
-            send_status_req = ssl.send_status_req
-            ssl_verify = (ssl.verify == nil) or (not not ssl.verify) -- default to true, and force to bool
-            ssl = true
-        else
-            if ssl then
-                ssl = true
-                ssl_verify = true       -- default to true
-            else
-                ssl = false
+            ssl_server_name = options.ssl.server_name
+            send_status_req = options.ssl.send_status_req
+            if options.ssl.ssl_verify == false then
+                ssl_verify = false
             end
         end
-    else
-        -- plain http
-        ssl = false
     end
 
     -- proxy related settings

--- a/lib/resty/http_connect.lua
+++ b/lib/resty/http_connect.lua
@@ -156,7 +156,11 @@ local function connect(self, options)
                    .. ":" .. (ssl_server_name or "")
                    .. ":" .. tostring(ssl_verify)
                    .. ":" .. (proxy_uri or "")
-                   .. ":" .. (proxy_authorization or "")
+                   .. ":" .. (request_scheme == "https" and proxy_authorization or "")
+        -- in the above we only add the 'proxy_authorization' as part of the poolname
+        -- when the request is https. Because in that case the CONNECT request (which
+        -- carries the authorization header) is part of the connect procedure, whereas
+        -- with a plain http request the authorization is part of the actual request.
     end
 
     -- do TCP level connection

--- a/lib/resty/http_connect.lua
+++ b/lib/resty/http_connect.lua
@@ -1,0 +1,209 @@
+local ngx_re_gmatch = ngx.re.gmatch
+local ngx_re_sub = ngx.re.sub
+local ngx_re_find = ngx.re.find
+
+--[[
+A connection function that incorporates:
+  - tcp connect
+  - ssl handshake
+  - http proxy
+Due to this it will be better at setting up a socket pool where connections can
+be kept alive.
+
+
+Call it with a single options table as follows:
+
+client:connect {
+    scheme = "https"        -- scheme to use, or nil for unix domain socket
+    host = "myhost.com",    -- target machine, or a unix domain socket
+    port = nil,             -- port on target machine, will default to 80/443 based on scheme
+    pool = nil,             -- connection pool name, leave blank! this function knows best!
+    pool_size = nil,        -- options as per: https://github.com/openresty/lua-nginx-module#tcpsockconnect
+    backlog = nil,
+
+    ssl = {                 -- ssl will be used when either scheme = https, or when ssl is truthy
+        server_name = nil,  -- options as per: https://github.com/openresty/lua-nginx-module#tcpsocksslhandshake
+        ssl_verify = true,  -- defaults to true
+        ctx = nil,          -- NOT supported
+    },
+
+    proxy = {               -- proxy will be used only if "proxy.uri" is provided
+        uri = "http://myproxy.internal:123", -- uri of the proxy
+        authorization = nil, -- a "Proxy-Authorization" header value to be used
+        no_proxy = nil,      -- comma separated string of domains bypassing proxy
+    },
+}
+]]
+local function connect(self, options)
+    local sock = self.sock
+    if not sock then
+        return nil, "not initialized"
+    end
+
+    local ok, err
+    local proxy_scheme = options.scheme -- scheme to use; http or https
+    local host = options.host -- remote host to connect to
+    local port = options.port -- remote port to connect to
+    local poolname = options.pool -- connection pool name to use
+    local pool_size = options.pool_size
+    local backlog = options.backlog
+    if proxy_scheme and not port then
+        port = (proxy_scheme == "https" and 443 or 80)
+    elseif port and not proxy_scheme then
+        return nil, "'scheme' is required when providing a port"
+    end
+
+    -- ssl settings
+    local ssl, ssl_server_name, ssl_verify
+    if proxy_scheme ~= "http" then
+        -- either https or unix domain socket
+        ssl = options.ssl
+        if type(options.ssl) == "table" then
+            ssl_server_name = ssl.server_name
+            ssl_verify = (ssl.verify == nil) or (not not ssl.verify) -- default to true, and force to bool
+            ssl = true
+        else
+            if ssl then
+                ssl = true
+                ssl_verify = true       -- default to true
+            else
+                ssl = false
+            end
+        end
+    else
+        -- plain http
+        ssl = false
+    end
+
+    -- proxy related settings
+    local proxy, proxy_uri, proxy_uri_t, proxy_authorization, proxy_host, proxy_port
+    proxy = options.proxy
+    if proxy and proxy.no_proxy then
+        -- Check if the no_proxy option matches this host. Implementation adapted
+        -- from lua-http library (https://github.com/daurnimator/lua-http)
+        if proxy.no_proxy == "*" then
+            -- all hosts are excluded
+            proxy = nil
+
+        else
+            local no_proxy_set = {}
+            -- wget allows domains in no_proxy list to be prefixed by "."
+            -- e.g. no_proxy=.mit.edu
+            for host_suffix in ngx_re_gmatch(proxy.no_proxy, "\\.?([^,]+)") do
+                no_proxy_set[host_suffix[1]] = true
+            end
+
+            -- From curl docs:
+            -- matched as either a domain which contains the hostname, or the
+            -- hostname itself. For example local.com would match local.com,
+            -- local.com:80, and www.local.com, but not www.notlocal.com.
+            --
+            -- Therefore, we keep stripping subdomains from the host, compare
+            -- them to the ones in the no_proxy list and continue until we find
+            -- a match or until there's only the TLD left
+            repeat
+                if no_proxy_set[host] then
+                    proxy = nil
+                    break
+                end
+
+                -- Strip the next level from the domain and check if that one
+                -- is on the list
+                host = ngx_re_sub(host, "^[^.]+\\.", "")
+            until not ngx_re_find(host, "\\.")
+        end
+    end
+
+    if proxy then
+        proxy_uri = proxy.uri  -- full uri to proxy (only http supported)
+        proxy_authorization = proxy.authorization -- auth to send via CONNECT
+        proxy_uri_t, err = self:parse_uri(proxy_uri)
+        if not proxy_uri_t then
+            return nil, err
+        end
+
+        local p_scheme = proxy_uri_t[1]
+        if p_scheme ~= "http" then
+            return nil, "protocol " .. p_scheme .. " not supported for proxy connections"
+        end
+        proxy_host = proxy_uri_t[2]
+        proxy_port = proxy_uri_t[3]
+    end
+
+    -- construct a poolname unique within proxy and ssl info
+    if not poolname then
+        poolname = (proxy_scheme or "")
+                   .. ":" .. host
+                   .. ":" .. tostring(port)
+                   .. ":" .. tostring(ssl)
+                   .. ":" .. (ssl_server_name or "")
+                   .. ":" .. tostring(ssl_verify)
+                   .. ":" .. (proxy_uri or "")
+                   .. ":" .. (proxy_authorization or "")
+    end
+
+    -- do TCP level connection
+    local tcp_opts = { pool = poolname, pool_size = pool_size, backlog = backlog }
+    if proxy then
+        -- proxy based connection
+        ok, err = sock:connect(proxy_host, proxy_port, tcp_opts)
+        if not ok then
+            return nil, err
+        end
+
+        if proxy and proxy_scheme == "https" and sock:getreusedtimes() == 0 then
+            -- Make a CONNECT request to create a tunnel to the destination through
+            -- the proxy. The request-target and the Host header must be in the
+            -- authority-form of RFC 7230 Section 5.3.3. See also RFC 7231 Section
+            -- 4.3.6 for more details about the CONNECT request
+            local destination = host .. ":" .. port
+            local res, err = self:request({
+                method = "CONNECT",
+                path = destination,
+                headers = {
+                    ["Host"] = destination,
+                    ["Proxy-Authorization"] = proxy_authorization,
+                }
+            })
+
+            if not res then
+                return nil, err
+            end
+
+            if res.status < 200 or res.status > 299 then
+                return nil, "failed to establish a tunnel through a proxy: " .. res.status
+            end
+        end
+
+    elseif not port then
+        -- non-proxy, without port -> unix domain socket
+        ok, err = sock:connect(host, tcp_opts)
+        if not ok then
+            return nil, err
+        end
+
+    else
+        -- non-proxy, regular network tcp
+        ok, err = sock:connect(host, port, tcp_opts)
+        if not ok then
+            return nil, err
+        end
+    end
+
+    -- Now do the ssl handshake
+    if ssl and sock:getreusedtimes() == 0 then
+        local ok, err = self:ssl_handshake(nil, ssl_server_name, ssl_verify)
+        if not ok then
+            self:close()
+            return nil, err
+        end
+    end
+
+    self.host = host
+    self.port = port
+    self.keepalive = true
+
+    return true
+end
+
+return connect

--- a/lib/resty/http_connect.lua
+++ b/lib/resty/http_connect.lua
@@ -23,6 +23,7 @@ client:connect {
 
     ssl = {                 -- ssl will be used when either scheme = https, or when ssl is truthy
         server_name = nil,  -- options as per: https://github.com/openresty/lua-nginx-module#tcpsocksslhandshake
+        send_status_req = nil,
         ssl_verify = true,  -- defaults to true
         ctx = nil,          -- NOT supported
     },
@@ -51,12 +52,13 @@ local function connect(self, options)
     end
 
     -- ssl settings
-    local ssl, ssl_server_name, ssl_verify
+    local ssl, ssl_server_name, ssl_verify, send_status_req
     if request_scheme ~= "http" then
         -- either https or unix domain socket
         ssl = options.ssl
         if type(options.ssl) == "table" then
             ssl_server_name = ssl.server_name
+            send_status_req = ssl.send_status_req
             ssl_verify = (ssl.verify == nil) or (not not ssl.verify) -- default to true, and force to bool
             ssl = true
         else
@@ -205,7 +207,7 @@ local function connect(self, options)
 
     -- Now do the ssl handshake
     if ssl and sock:getreusedtimes() == 0 then
-        local ok, err = self:ssl_handshake(nil, ssl_server_name, ssl_verify)
+        local ok, err = self:ssl_handshake(nil, ssl_server_name, ssl_verify, send_status_req)
         if not ok then
             self:close()
             return nil, err

--- a/lib/resty/http_connect.lua
+++ b/lib/resty/http_connect.lua
@@ -75,7 +75,7 @@ local function connect(self, options)
     end
 
     -- proxy related settings
-    local proxy, proxy_uri, proxy_uri_t, proxy_authorization, proxy_host, proxy_port
+    local proxy, proxy_uri, proxy_authorization, proxy_host, proxy_port
     proxy = self.proxy_opts
 
     if proxy then
@@ -131,7 +131,7 @@ local function connect(self, options)
     end
 
     if proxy then
-        proxy_uri_t, err = self:parse_uri(proxy_uri)
+        local proxy_uri_t, err = self:parse_uri(proxy_uri)
         if not proxy_uri_t then
             return nil, err
         end

--- a/lua-resty-http-0.15-0.rockspec
+++ b/lua-resty-http-0.15-0.rockspec
@@ -17,7 +17,7 @@ build = {
     type = "builtin",
     modules = {
         ["resty.http"] = "lib/resty/http.lua",
-        ["resty.http_headers"] = "lib/resty/http_headers.lua"
+        ["resty.http_headers"] = "lib/resty/http_headers.lua",
         ["resty.http_connect"] = "lib/resty/http_connect.lua"
     }
 }

--- a/lua-resty-http-0.15-0.rockspec
+++ b/lua-resty-http-0.15-0.rockspec
@@ -1,22 +1,23 @@
 package = "lua-resty-http"
 version = "0.15-0"
 source = {
-   url = "git://github.com/ledgetech/lua-resty-http",
-   tag = "v0.15"
+    url = "git://github.com/ledgetech/lua-resty-http",
+    tag = "v0.15"
 }
 description = {
-   summary = "Lua HTTP client cosocket driver for OpenResty / ngx_lua.",
-   homepage = "https://github.com/ledgetech/lua-resty-http",
-   license = "2-clause BSD",
-   maintainer = "James Hurst <james@pintsized.co.uk>"
+    summary = "Lua HTTP client cosocket driver for OpenResty / ngx_lua.",
+    homepage = "https://github.com/ledgetech/lua-resty-http",
+    license = "2-clause BSD",
+    maintainer = "James Hurst <james@pintsized.co.uk>"
 }
 dependencies = {
-   "lua >= 5.1"
+    "lua >= 5.1"
 }
 build = {
-   type = "builtin",
-   modules = {
-      ["resty.http"] = "lib/resty/http.lua",
-      ["resty.http_headers"] = "lib/resty/http_headers.lua"
-   }
+    type = "builtin",
+    modules = {
+        ["resty.http"] = "lib/resty/http.lua",
+        ["resty.http_headers"] = "lib/resty/http_headers.lua"
+        ["resty.http_connect"] = "lib/resty/http_connect.lua"
+    }
 }

--- a/t/07-keepalive.t
+++ b/t/07-keepalive.t
@@ -34,13 +34,15 @@ __DATA__
             local http = require "resty.http"
             local httpc = http.new()
             local res, err = httpc:request_uri(
-                "http://127.0.0.1:"..ngx.var.server_port.."/b", {
-                }
+                "http://127.0.0.1:" .. ngx.var.server_port.."/b", {}
             )
-
             ngx.say(res.headers["Connection"])
 
-            httpc:connect("127.0.0.1", ngx.var.server_port)
+            httpc:connect {
+                scheme = "http",
+                host = "127.0.0.1",
+                port = ngx.var.server_port
+            }
             ngx.say(httpc:get_reused_times())
         ';
     }
@@ -261,7 +263,11 @@ connection must be closed
 
             ngx.say(res.headers["Connection"])
 
-            httpc:connect("127.0.0.1", ngx.var.server_port)
+            httpc:connect {
+                scheme = "http",
+                host = "127.0.0.1",
+                port = ngx.var.server_port
+            }
             ngx.say(httpc:get_reused_times())
             httpc:close()
 
@@ -274,7 +280,11 @@ connection must be closed
 
             ngx.say(res.headers["Connection"])
 
-            httpc:connect("127.0.0.1", ngx.var.server_port)
+            httpc:connect {
+                scheme = "http",
+                host = "127.0.0.1",
+                port = ngx.var.server_port
+            }
             ngx.say(httpc:get_reused_times())
             httpc:close()
 
@@ -289,7 +299,11 @@ connection must be closed
 
             ngx.sleep(1.1)
 
-            httpc:connect("127.0.0.1", ngx.var.server_port)
+            httpc:connect {
+                scheme = "http",
+                host = "127.0.0.1",
+                port = ngx.var.server_port
+            }
             ngx.say(httpc:get_reused_times())
             httpc:close()
         }

--- a/t/16-http-proxy.t
+++ b/t/16-http-proxy.t
@@ -394,7 +394,7 @@ Basic ZGVtbzp0ZXN0
     }
 --- tcp_listen: 12345
 --- tcp_query eval
-qr/CONNECT 127.0.0.1:443 HTTP\/1.1\r\n.*Proxy-Authorization: Basic ZGVtbzpwYXNz\r\n.*Host: 127.0.0.1:443\r\n.*/s
+qr/CONNECT 127.0.0.1:443 HTTP\/1.1\r\n.*Proxy-Authorization: Basic ZGVtbzpwYXNz\r\n.*/s
 
 # The reply cannot be successful or otherwise the client would start
 # to do a TLS handshake with the proxied host and that we cannot
@@ -505,7 +505,7 @@ Basic ZGVtbzp3b3Jk
     }
 --- tcp_listen: 12345
 --- tcp_query eval
-qr/CONNECT 127.0.0.1:443 HTTP\/1.1\r\n.*Proxy-Authorization: Basic ZGVtbzp3b3Jk\r\n.*Host: 127.0.0.1:443\r\n.*/s
+qr/CONNECT 127.0.0.1:443 HTTP\/1.1\r\n.*Proxy-Authorization: Basic ZGVtbzp3b3Jk\r\n.*/s
 
 # The reply cannot be successful or otherwise the client would start
 # to do a TLS handshake with the proxied host and that we cannot


### PR DESCRIPTION
Here's the second option for safe keep-alive across ssl + proxy connections.

It implements a new connect method that does it all at once (connect, ssl-handshake, proxy)

This is (imo the better) alternative to https://github.com/ledgetech/lua-resty-http/pull/202 .

There are no tests since this is very hard to test without a proxy server. Yet tests are available in the originating code here: https://github.com/Kong/kong-plugin-aws-lambda/compare/better-connect?expand=1 , which includes a forward-proxy and full integration tests.

Input is appreciated  @hamishforbes @pintsized @bungle .

replaces #201 
fixes #161 
replaces #205 