### PR TITLE
doc: improved the code examples in Synopsis

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ server {
         headers = {
           ["Content-Type"] = "application/x-www-form-urlencoded",
         },
-        keepalive_timeout = 60,
+        keepalive_timeout = 60000,
         keepalive_pool = 10
       })
 


### PR DESCRIPTION
60 milliseconds is too short. When testing, it will be mistaken for keepalive not taking effect.