### PR TITLE
Update documentation to reflect deprecated features

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Attempts to connect to the web server while incorporating the following activiti
 - SSL handshake
 - HTTP proxy configuration
 
-In doing so it will create a distinct connection pool name that is safe to use with SSL and / or proxy based connections, and as such this syntax is strongly recommended over the original [deprecated connection syntax](#TCP-only-connect).
+In doing so it will create a distinct connection pool name that is safe to use with SSL and / or proxy based connections, and as such this syntax is strongly recommended over the original (now deprecated) [TCP only connection syntax](#TCP-only-connect).
 
 The options table has the following fields:
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Attempts to connect to the web server while incorporating the following activiti
 - SSL handshake
 - HTTP proxy configuration
 
-In doing so it will create a distinct connection pool name that is safe to use with SSL and / or proxy based connections, and as such this syntax is strongly recommended over the original [deprecated connection syntax](#TCP_only_connect).
+In doing so it will create a distinct connection pool name that is safe to use with SSL and / or proxy based connections, and as such this syntax is strongly recommended over the original [deprecated connection syntax](#TCP-only-connect).
 
 The options table has the following fields:
 
@@ -210,7 +210,7 @@ Configure an HTTP proxy to be used with this client instance. The `opts` table e
 * `https_proxy_authorization`: as `http_proxy_authorization` but for use with `https_proxy` (since with HTTPS the authorisation is done when connecting, this one cannot be overridden by passing the `Proxy-Authorization` request header).
 * `no_proxy`: a comma separated list of hosts that should not be proxied.
 
-Note that this method has no effect when using the deprecated [TCP only connect](#TCP_only_connect) connection syntax.
+Note that this method has no effect when using the deprecated [TCP only connect](#TCP-only-connect) connection syntax.
 
 ## get\_reused\_times
 
@@ -405,7 +405,7 @@ NOTE: the default pool name will only incorporate IP and port information so is 
 
 `syntax: ok, err = httpc:connect_proxy(proxy_uri, scheme, host, port, proxy_authorization)`
 
-*Calling this method manually is no longer necessary since it is incorporated within [connect](#connect). It is retained for now for compatibility with users of the older [TCP only connect](#TCP_only_connect) syntax.*
+*Calling this method manually is no longer necessary since it is incorporated within [connect](#connect). It is retained for now for compatibility with users of the older [TCP only connect](#TCP-only-connect) syntax.*
 
 Attempts to connect to the web server through the given proxy server. The method accepts the following arguments:
 
@@ -426,7 +426,7 @@ There's a few key points to keep in mind when using this api:
 
 `syntax: session, err = httpc:ssl_handshake(session, host, verify)`
 
-*Calling this method manually is no longer necessary since it is incorporated within [connect](#connect). It is retained for now for compatibility with users of the older [TCP only connect](#TCP_only_connect) syntax.*
+*Calling this method manually is no longer necessary since it is incorporated within [connect](#connect). It is retained for now for compatibility with users of the older [TCP only connect](#TCP-only-connect) syntax.*
 
 See [OpenResty docs](https://github.com/openresty/lua-nginx-module#ngxsockettcp).
 

--- a/lib/resty/http.lua
+++ b/lib/resty/http.lua
@@ -22,6 +22,7 @@ local ngx_log = ngx.log
 local ngx_DEBUG = ngx.DEBUG
 local ngx_ERR = ngx.ERR
 local ngx_WARN = ngx.WARN
+local ngx_var = ngx.var
 local ngx_print = ngx.print
 local ngx_header = ngx.header
 local co_yield = coroutine.yield

--- a/lib/resty/http.lua
+++ b/lib/resty/http.lua
@@ -180,6 +180,8 @@ do
 end
 
 function _M.tcp_only_connect(self, ...)
+    ngx_log(ngx_WARN, "Use of deprecated `connect` method signature")
+
     local sock = self.sock
     if not sock then
         return nil, "not initialized"

--- a/lib/resty/http.lua
+++ b/lib/resty/http.lua
@@ -181,7 +181,7 @@ do
 end
 
 function _M.tcp_only_connect(self, ...)
-    ngx_log(ngx_WARN, "Use of deprecated `connect` method signature")
+    ngx_log(ngx_DEBUG, "Use of deprecated `connect` method signature")
 
     local sock = self.sock
     if not sock then
@@ -1014,7 +1014,7 @@ end
 -- ----------------------------------------------------------------------------
 
 function _M.ssl_handshake(self, ...)
-    ngx_log(ngx_WARN, "Use of deprecated function `ssl_handshake`")
+    ngx_log(ngx_DEBUG, "Use of deprecated function `ssl_handshake`")
 
     local sock = self.sock
     if not sock then
@@ -1028,7 +1028,7 @@ end
 
 
 function _M.connect_proxy(self, proxy_uri, scheme, host, port, proxy_authorization)
-    ngx_log(ngx_WARN, "Use of deprecated function `connect_proxy`")
+    ngx_log(ngx_DEBUG, "Use of deprecated function `connect_proxy`")
 
     -- Parse the provided proxy URI
     local parsed_proxy_uri, err = self:parse_uri(proxy_uri, false)
@@ -1079,7 +1079,7 @@ end
 
 
 function _M.proxy_request(self, chunksize)
-    ngx_log(ngx_WARN, "Use of deprecated function `proxy_request`")
+    ngx_log(ngx_DEBUG, "Use of deprecated function `proxy_request`")
 
     return self:request({
         method = ngx_req_get_method(),
@@ -1091,7 +1091,7 @@ end
 
 
 function _M.proxy_response(_, response, chunksize)
-    ngx_log(ngx_WARN, "Use of deprecated function `proxy_response`")
+    ngx_log(ngx_DEBUG, "Use of deprecated function `proxy_response`")
 
     if not response then
         ngx_log(ngx_ERR, "no response provided")

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -1,7 +1,5 @@
-use Test::Nginx::Socket;
+use Test::Nginx::Socket 'no_plan';
 use Cwd qw(cwd);
-
-plan tests => repeat_each() * (blocks() * 4) + 1;
 
 my $pwd = cwd();
 

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -33,7 +33,11 @@ __DATA__
         content_by_lua '
             local http = require "resty.http"
             local httpc = http.new()
-            httpc:connect("127.0.0.1", ngx.var.server_port)
+            httpc:connect{
+                scheme = "http",
+                host = "127.0.0.1",
+                port = ngx.var.server_port
+            }
 
             local res, err = httpc:request{
                 path = "/b"
@@ -64,7 +68,11 @@ OK
         content_by_lua '
             local http = require "resty.http"
             local httpc = http.new()
-            httpc:connect("127.0.0.1", ngx.var.server_port)
+            httpc:connect{
+                scheme = "http",
+                host = "127.0.0.1",
+                port = ngx.var.server_port
+            }
 
             local res, err = httpc:request{
                 version = 1.0,
@@ -96,7 +104,11 @@ OK
         content_by_lua '
             local http = require "resty.http"
             local httpc = http.new()
-            httpc:connect("127.0.0.1", ngx.var.server_port)
+            local ok, err = httpc:connect{
+                scheme = "http",
+                host = "127.0.0.1",
+                port = ngx.var.server_port
+            }
 
             local res, err = httpc:request{
                 path = "/b"
@@ -133,7 +145,11 @@ OK
         content_by_lua '
             local http = require "resty.http"
             local httpc = http.new()
-            httpc:connect("127.0.0.1", ngx.var.server_port)
+            httpc:connect{
+                scheme = "http",
+                host = "127.0.0.1",
+                port = ngx.var.server_port
+            }
 
             local res, err = httpc:request{
                 path = "/b"
@@ -167,7 +183,11 @@ x-value
         content_by_lua '
             local http = require "resty.http"
             local httpc = http.new()
-            httpc:connect("127.0.0.1", ngx.var.server_port)
+            httpc:connect{
+                scheme = "http",
+                host = "127.0.0.1",
+                port = ngx.var.server_port
+            }
 
             local res, err = httpc:request{
                 query = {
@@ -212,7 +232,11 @@ X-Header-B: 2
         content_by_lua '
             local http = require "resty.http"
             local httpc = http.new()
-            httpc:connect("127.0.0.1", ngx.var.server_port)
+            httpc:connect{
+                scheme = "http",
+                host = "127.0.0.1",
+                port = ngx.var.server_port
+            }
 
             local res, err = httpc:request{
                 method = "HEAD",
@@ -245,13 +269,14 @@ GET /a
         content_by_lua '
             local http = require "resty.http"
 
-            local res, err = http:connect("127.0.0.1", 1984)
+            local res, err = http:connect{
+                scheme = "http",
+                host = "127.0.0.1",
+                port = ngx.var.server_port
+            }
             if not res then ngx.say(err) end
 
             local res, err = http:set_timeout(500)
-            if not res then ngx.say(err) end
-
-            local res, err = http:ssl_handshake()
             if not res then ngx.say(err) end
 
             local res, err = http:set_keepalive()
@@ -267,7 +292,6 @@ GET /a
 --- request
 GET /a
 --- response_body
-not initialized
 not initialized
 not initialized
 not initialized
@@ -382,8 +406,11 @@ scheme: http, host: example.com, port: 80, path: /foo/bar?a=1&b=2
 
             -- Create a TCP connection and return an raw HTTP-response because
             -- there is no way to set an empty header value in nginx.
-            assert(httpc:connect("127.0.0.1", 12345),
-                "connect should return positively")
+            assert(httpc:connect{
+                scheme = "http",
+                host = "127.0.0.1",
+                port = 12345,
+            }, "connect should return positively")
 
             local res = httpc:request({ path = "/b" })
             if res.headers["X-Header-Empty"] == "" then

--- a/t/02-chunked.t
+++ b/t/02-chunked.t
@@ -31,7 +31,11 @@ __DATA__
         content_by_lua '
             local http = require "resty.http"
             local httpc = http.new()
-            httpc:connect("127.0.0.1", ngx.var.server_port)
+            httpc:connect({
+                scheme = "http",
+                host = "127.0.0.1",
+                port = ngx.var.server_port
+            })
 
             local res, err = httpc:request{
                 path = "/b"
@@ -70,7 +74,11 @@ GET /a
         content_by_lua '
             local http = require "resty.http"
             local httpc = http.new()
-            httpc:connect("127.0.0.1", ngx.var.server_port)
+            httpc:connect({
+                scheme = "http",
+                host = "127.0.0.1",
+                port = ngx.var.server_port
+            })
 
             local res, err = httpc:request{
                 path = "/b"
@@ -126,7 +134,11 @@ GET /a
         content_by_lua '
             local http = require "resty.http"
             local httpc = http.new()
-            httpc:connect("127.0.0.1", ngx.var.server_port)
+            httpc:connect({
+                scheme = "http",
+                host = "127.0.0.1",
+                port = ngx.var.server_port
+            })
 
             local res, err = httpc:request{
                 path = "/b"
@@ -170,7 +182,11 @@ GET /a
         content_by_lua_block {
             local http = require "resty.http"
             local httpc = http.new()
-            httpc:connect("127.0.0.1", ngx.var.server_port)
+            httpc:connect({
+                scheme = "http",
+                host = "127.0.0.1",
+                port = ngx.var.server_port
+            })
 
             local res, err = httpc:request{
                 path = "/b"

--- a/t/03-requestbody.t
+++ b/t/03-requestbody.t
@@ -33,7 +33,11 @@ __DATA__
         content_by_lua '
             local http = require "resty.http"
             local httpc = http.new()
-            httpc:connect("127.0.0.1", ngx.var.server_port)
+            httpc:connect({
+                scheme = "http",
+                host = "127.0.0.1",
+                port = ngx.var.server_port
+            })
 
             local res, err = httpc:request{
                 body = "a=1&b=2&c=3",
@@ -74,7 +78,11 @@ c: 3
         content_by_lua '
             local http = require "resty.http"
             local httpc = http.new()
-            httpc:connect("127.0.0.1", ngx.var.server_port)
+            httpc:connect({
+                scheme = "http",
+                host = "127.0.0.1",
+                port = ngx.var.server_port
+            })
 
             local res, err = httpc:request{
                 method = "POST",
@@ -119,7 +127,11 @@ c: 3
         content_by_lua '
             local http = require "resty.http"
             local httpc = http.new()
-            httpc:connect("127.0.0.1", ngx.var.server_port)
+            httpc:connect({
+                scheme = "http",
+                host = "127.0.0.1",
+                port = ngx.var.server_port
+            })
 
             local res, err = httpc:request{
                 body = "a=1&b=2&c=3",
@@ -161,7 +173,11 @@ c: 3
         content_by_lua '
             local http = require "resty.http"
             local httpc = http.new()
-            httpc:connect("127.0.0.1", ngx.var.server_port)
+            httpc:connect({
+                scheme = "http",
+                host = "127.0.0.1",
+                port = ngx.var.server_port
+            })
 
             local res, err = httpc:request{
                 path = "/b",

--- a/t/03-requestbody.t
+++ b/t/03-requestbody.t
@@ -1,7 +1,5 @@
-use Test::Nginx::Socket;
+use Test::Nginx::Socket 'no_plan';
 use Cwd qw(cwd);
-
-plan tests => repeat_each() * (blocks() * 4);
 
 my $pwd = cwd();
 

--- a/t/04-trailers.t
+++ b/t/04-trailers.t
@@ -33,7 +33,11 @@ __DATA__
         content_by_lua '
             local http = require "resty.http"
             local httpc = http.new()
-            httpc:connect("127.0.0.1", ngx.var.server_port)
+            httpc:connect({
+                scheme = "http",
+                host = "127.0.0.1",
+                port = ngx.var.server_port
+            })
 
             local res, err = httpc:request{
                 path = "/b",
@@ -101,7 +105,11 @@ OK
         content_by_lua '
             local http = require "resty.http"
             local httpc = http.new()
-            httpc:connect("127.0.0.1", ngx.var.server_port)
+            httpc:connect({
+                scheme = "http",
+                host = "127.0.0.1",
+                port = ngx.var.server_port
+            })
 
             local res, err = httpc:request{
                 path = "/b",

--- a/t/04-trailers.t
+++ b/t/04-trailers.t
@@ -1,7 +1,5 @@
-use Test::Nginx::Socket;
+use Test::Nginx::Socket 'no_plan';
 use Cwd qw(cwd);
-
-plan tests => repeat_each() * (blocks() * 4);
 
 my $pwd = cwd();
 

--- a/t/05-stream.t
+++ b/t/05-stream.t
@@ -33,7 +33,11 @@ __DATA__
         content_by_lua '
             local http = require "resty.http"
             local httpc = http.new()
-            httpc:connect("127.0.0.1", ngx.var.server_port)
+            httpc:connect({
+                scheme = "http",
+                host = "127.0.0.1",
+                port = ngx.var.server_port
+            })
 
             local res, err = httpc:request{
                 path = "/b",
@@ -81,7 +85,11 @@ chunked
         content_by_lua '
             local http = require "resty.http"
             local httpc = http.new()
-            httpc:connect("127.0.0.1", ngx.var.server_port)
+            httpc:connect({
+                scheme = "http",
+                host = "127.0.0.1",
+                port = ngx.var.server_port
+            })
 
             local res, err = httpc:request{
                 path = "/b",
@@ -132,7 +140,11 @@ nil
         content_by_lua '
             local http = require "resty.http"
             local httpc = http.new()
-            httpc:connect("127.0.0.1", ngx.var.server_port)
+            httpc:connect({
+                scheme = "http",
+                host = "127.0.0.1",
+                port = ngx.var.server_port
+            })
 
             local res, err = httpc:request{
                 path = "/b",
@@ -181,7 +193,11 @@ Buffer size not specified, bailing
         content_by_lua '
             local http = require "resty.http"
             local httpc = http.new()
-            httpc:connect("127.0.0.1", ngx.var.server_port)
+            httpc:connect({
+                scheme = "http",
+                host = "127.0.0.1",
+                port = ngx.var.server_port
+            })
 
             local res, err = httpc:request{
                 path = "/b",
@@ -233,7 +249,11 @@ nil
         content_by_lua '
             local http = require "resty.http"
             local httpc = http.new()
-            httpc:connect("127.0.0.1", ngx.var.server_port)
+            httpc:connect({
+                scheme = "http",
+                host = "127.0.0.1",
+                port = ngx.var.server_port
+            })
 
             local res, err = httpc:request{
                 path = "/b",
@@ -287,7 +307,11 @@ nil
         content_by_lua '
             local http = require "resty.http"
             local httpc = http.new()
-            httpc:connect("127.0.0.1", ngx.var.server_port)
+            httpc:connect({
+                scheme = "http",
+                host = "127.0.0.1",
+                port = ngx.var.server_port
+            })
 
             local res, err = httpc:request{
                 path = "/b",
@@ -350,7 +374,11 @@ GET /a
         content_by_lua '
             local http = require "resty.http"
             local httpc = http.new()
-            httpc:connect("127.0.0.1", ngx.var.server_port)
+            httpc:connect({
+                scheme = "http",
+                host = "127.0.0.1",
+                port = ngx.var.server_port
+            })
 
             local res, err = httpc:request{
                 path = "/b",
@@ -466,7 +494,11 @@ foobarbazfoobarbazfoobarbazfoobarbazfoobarbazfoobarbazfoobarbazfoobarbazfoobarba
         content_by_lua '
             local http = require "resty.http"
             local httpc = http.new()
-            httpc:connect("127.0.0.1", ngx.var.server_port)
+            httpc:connect({
+                scheme = "http",
+                host = "127.0.0.1",
+                port = ngx.var.server_port
+            })
 
             local reader, err = httpc:get_client_body_reader(64)
 
@@ -509,7 +541,11 @@ foobarbazfoobarbazfoobarbazfoobarbazfoobarbazfoobarbazfoobarbazfoobarbazfoobarba
         content_by_lua '
             local http = require "resty.http"
             local httpc = http.new()
-            httpc:connect("127.0.0.1", ngx.var.server_port)
+            httpc:connect({
+                scheme = "http",
+                host = "127.0.0.1",
+                port = ngx.var.server_port
+            })
 
             local res, err = httpc:request{
                 path = "/b",

--- a/t/05-stream.t
+++ b/t/05-stream.t
@@ -1,7 +1,5 @@
-use Test::Nginx::Socket;
+use Test::Nginx::Socket 'no_plan';
 use Cwd qw(cwd);
-
-plan tests => repeat_each() * (blocks() * 4) - 1;
 
 my $pwd = cwd();
 

--- a/t/07-keepalive.t
+++ b/t/07-keepalive.t
@@ -77,12 +77,20 @@ keep-alive
                 }
             )
 
-            httpc:connect("127.0.0.1", ngx.var.server_port)
+            httpc:connect({
+                scheme = "http",
+                host = "127.0.0.1",
+                port = ngx.var.server_port
+            })
             ngx.say(httpc:get_reused_times())
 
             httpc:set_keepalive()
 
-            httpc:connect("127.0.0.1", ngx.var.server_port)
+            httpc:connect({
+                scheme = "http",
+                host = "127.0.0.1",
+                port = ngx.var.server_port
+            })
             ngx.say(httpc:get_reused_times())
         ';
     }
@@ -108,7 +116,11 @@ GET /a
         content_by_lua '
             local http = require "resty.http"
             local httpc = http.new()
-            httpc:connect("127.0.0.1", ngx.var.server_port)
+            httpc:connect({
+                scheme = "http",
+                host = "127.0.0.1",
+                port = ngx.var.server_port
+            })
 
             local res, err = httpc:request{
                 path = "/b"
@@ -119,7 +131,11 @@ GET /a
             ngx.say(res.headers["Connection"])
             ngx.say(httpc:set_keepalive())
 
-            httpc:connect("127.0.0.1", ngx.var.server_port)
+            httpc:connect({
+                scheme = "http",
+                host = "127.0.0.1",
+                port = ngx.var.server_port
+            })
             ngx.say(httpc:get_reused_times())
         ';
     }
@@ -146,7 +162,11 @@ keep-alive
         content_by_lua '
             local http = require "resty.http"
             local httpc = http.new()
-            httpc:connect("127.0.0.1", ngx.var.server_port)
+            httpc:connect({
+                scheme = "http",
+                host = "127.0.0.1",
+                port = ngx.var.server_port
+            })
 
             local res, err = httpc:request{
                 version = 1.0,
@@ -163,12 +183,20 @@ keep-alive
             ngx.say(r)
             ngx.say(e)
 
-            httpc:connect("127.0.0.1", ngx.var.server_port)
+            httpc:connect({
+                scheme = "http",
+                host = "127.0.0.1",
+                port = ngx.var.server_port
+            })
             ngx.say(httpc:get_reused_times())
 
             httpc:set_keepalive()
 
-            httpc:connect("127.0.0.1", ngx.var.server_port)
+            httpc:connect({
+                scheme = "http",
+                host = "127.0.0.1",
+                port = ngx.var.server_port
+            })
             ngx.say(httpc:get_reused_times())
         ';
     }
@@ -197,7 +225,11 @@ connection must be closed
         content_by_lua '
             local http = require "resty.http"
             local httpc = http.new()
-            httpc:connect("127.0.0.1", 12345)
+            httpc:connect({
+                scheme = "http",
+                host = "127.0.0.1",
+                port = 12345,
+            })
 
             local res, err = httpc:request{
                 version = 1.0,
@@ -213,12 +245,20 @@ connection must be closed
             ngx.say(r)
             ngx.say(e)
 
-            httpc:connect("127.0.0.1", ngx.var.server_port)
+            httpc:connect({
+                scheme = "http",
+                host = "127.0.0.1",
+                port = ngx.var.server_port
+            })
             ngx.say(httpc:get_reused_times())
 
             httpc:set_keepalive()
 
-            httpc:connect("127.0.0.1", ngx.var.server_port)
+            httpc:connect({
+                scheme = "http",
+                host = "127.0.0.1",
+                port = ngx.var.server_port
+            })
             ngx.say(httpc:get_reused_times())
         ';
     }
@@ -336,8 +376,11 @@ keep-alive
 
             -- Create a TCP connection and return an raw HTTP-response because
             -- there is no way to set an "Connection: Upgrade, close" header in nginx.
-            assert(httpc:connect("127.0.0.1", 12345),
-                "connect should return positively")
+            assert(httpc:connect({
+                scheme = "http",
+                host = "127.0.0.1",
+                port = 12345,
+            }), "connect should return positively")
 
             local res = httpc:request({
                 version = 1.1,
@@ -353,12 +396,20 @@ keep-alive
             ngx.say(r)
             ngx.say(e)
 
-            httpc:connect("127.0.0.1", ngx.var.server_port)
+            httpc:connect({
+                scheme = "http",
+                host = "127.0.0.1",
+                port = ngx.var.server_port
+            })
             ngx.say(httpc:get_reused_times())
 
             httpc:set_keepalive()
 
-            httpc:connect("127.0.0.1", ngx.var.server_port)
+            httpc:connect({
+                scheme = "http",
+                host = "127.0.0.1",
+                port = ngx.var.server_port
+            })
             ngx.say(httpc:get_reused_times())
         }
     }

--- a/t/07-keepalive.t
+++ b/t/07-keepalive.t
@@ -1,7 +1,5 @@
-use Test::Nginx::Socket;
+use Test::Nginx::Socket 'no_plan';
 use Cwd qw(cwd);
-
-plan tests => repeat_each() * (blocks() * 4);
 
 my $pwd = cwd();
 

--- a/t/08-pipeline.t
+++ b/t/08-pipeline.t
@@ -33,7 +33,11 @@ __DATA__
         content_by_lua '
             local http = require "resty.http"
             local httpc = http.new()
-            httpc:connect("127.0.0.1", ngx.var.server_port)
+            httpc:connect({
+                scheme = "http",
+                host = "127.0.0.1",
+                port = ngx.var.server_port
+            })
 
             local responses = httpc:request_pipeline{
                 {
@@ -101,7 +105,11 @@ D
         content_by_lua '
             local http = require "resty.http"
             local httpc = http.new()
-            httpc:connect("127.0.0.1", ngx.var.server_port)
+            httpc:connect({
+                scheme = "http",
+                host = "127.0.0.1",
+                port = ngx.var.server_port
+            })
             httpc:set_timeout(1)
 
             local responses = httpc:request_pipeline{

--- a/t/08-pipeline.t
+++ b/t/08-pipeline.t
@@ -1,7 +1,5 @@
-use Test::Nginx::Socket;
+use Test::Nginx::Socket 'no_plan';
 use Cwd qw(cwd);
-
-plan tests => repeat_each() * (blocks() * 4);
 
 my $pwd = cwd();
 

--- a/t/09-ssl.t
+++ b/t/09-ssl.t
@@ -1,7 +1,5 @@
-use Test::Nginx::Socket;
+use Test::Nginx::Socket 'no_plan';
 use Cwd qw(cwd);
-
-plan tests => repeat_each() * (blocks() * 4);
 
 my $pwd = cwd();
 

--- a/t/10-clientbodyreader.t
+++ b/t/10-clientbodyreader.t
@@ -36,7 +36,11 @@ __DATA__
         content_by_lua '
             local http = require "resty.http"
             local httpc = http.new()
-            httpc:connect("127.0.0.1", ngx.var.server_port)
+            httpc:connect({
+                scheme = "http",
+                host = "127.0.0.1",
+                port = ngx.var.server_port,
+            })
 
             local res, err = httpc:request{
                 path = "/c",

--- a/t/10-clientbodyreader.t
+++ b/t/10-clientbodyreader.t
@@ -1,7 +1,5 @@
-use Test::Nginx::Socket;
+use Test::Nginx::Socket 'no_plan';
 use Cwd qw(cwd);
-
-plan tests => repeat_each() * (blocks() * 4);
 
 my $pwd = cwd();
 

--- a/t/11-proxy.t
+++ b/t/11-proxy.t
@@ -1,7 +1,5 @@
-use Test::Nginx::Socket;
+use Test::Nginx::Socket 'no_plan';
 use Cwd qw(cwd);
-
-plan tests => repeat_each() * (blocks() * 5);
 
 my $pwd = cwd();
 

--- a/t/11-proxy.t
+++ b/t/11-proxy.t
@@ -60,8 +60,9 @@ X-Test: foo
 --- error_code: 200
 --- no_error_log
 [error]
---- error_log
 [warn]
+--- error_log
+[debug]
 
 
 === TEST 2: Proxy POST request and response
@@ -104,6 +105,8 @@ X-Test: foo
 [error]
 --- error_log
 [warn]
+--- error_log
+[debug]
 
 
 === TEST 3: Proxy multiple headers
@@ -138,8 +141,9 @@ OK
 --- error_code: 200
 --- no_error_log
 [error]
---- error_log
 [warn]
+--- error_log
+[debug]
 
 
 === TEST 4: Proxy still works with spaces in URI
@@ -175,5 +179,6 @@ X-Test: foo
 --- error_code: 200
 --- no_error_log
 [error]
---- error_log
 [warn]
+--- error_log
+[debug]

--- a/t/11-proxy.t
+++ b/t/11-proxy.t
@@ -35,7 +35,11 @@ __DATA__
         content_by_lua '
             local http = require "resty.http"
             local httpc = http.new()
-            httpc:connect("127.0.0.1", ngx.var.server_port)
+            httpc:connect({
+                scheme = "http",
+                host = "127.0.0.1",
+                port = ngx.var.server_port,
+            })
             httpc:proxy_response(httpc:proxy_request())
             httpc:set_keepalive()
         ';
@@ -56,6 +60,7 @@ X-Test: foo
 --- error_code: 200
 --- no_error_log
 [error]
+--- error_log
 [warn]
 
 
@@ -67,7 +72,11 @@ X-Test: foo
         content_by_lua '
             local http = require "resty.http"
             local httpc = http.new()
-            httpc:connect("127.0.0.1", ngx.var.server_port)
+            httpc:connect({
+                scheme = "http",
+                host = "127.0.0.1",
+                port = ngx.var.server_port,
+            })
             httpc:proxy_response(httpc:proxy_request())
             httpc:set_keepalive()
         ';
@@ -93,6 +102,7 @@ X-Test: foo
 --- error_code: 404
 --- no_error_log
 [error]
+--- error_log
 [warn]
 
 
@@ -104,7 +114,11 @@ X-Test: foo
         content_by_lua '
             local http = require "resty.http"
             local httpc = http.new()
-            httpc:connect("127.0.0.1", ngx.var.server_port)
+            httpc:connect({
+                scheme = "http",
+                host = "127.0.0.1",
+                port = ngx.var.server_port,
+            })
             httpc:proxy_response(httpc:proxy_request())
             httpc:set_keepalive()
         ';
@@ -124,6 +138,7 @@ OK
 --- error_code: 200
 --- no_error_log
 [error]
+--- error_log
 [warn]
 
 
@@ -135,7 +150,11 @@ OK
         content_by_lua '
             local http = require "resty.http"
             local httpc = http.new()
-            httpc:connect("127.0.0.1", ngx.var.server_port)
+            httpc:connect({
+                scheme = "http",
+                host = "127.0.0.1",
+                port = ngx.var.server_port,
+            })
             httpc:proxy_response(httpc:proxy_request())
             httpc:set_keepalive()
         ';
@@ -156,4 +175,5 @@ X-Test: foo
 --- error_code: 200
 --- no_error_log
 [error]
+--- error_log
 [warn]

--- a/t/13-default-path.t
+++ b/t/13-default-path.t
@@ -1,7 +1,5 @@
-use Test::Nginx::Socket;
+use Test::Nginx::Socket 'no_plan';
 use Cwd qw(cwd);
-
-plan tests => repeat_each() * (blocks() * 3);
 
 my $pwd = cwd();
 

--- a/t/14-host-header.t
+++ b/t/14-host-header.t
@@ -1,7 +1,5 @@
-use Test::Nginx::Socket;
+use Test::Nginx::Socket 'no_plan';
 use Cwd qw(cwd);
-
-plan tests => repeat_each() * (blocks() * 3);
 
 my $pwd = cwd();
 

--- a/t/16-http-proxy.t
+++ b/t/16-http-proxy.t
@@ -1,7 +1,5 @@
-use Test::Nginx::Socket;
+use Test::Nginx::Socket 'no_plan';
 use Cwd qw(cwd);
-
-plan tests => repeat_each() * (blocks() * 4);
 
 my $pwd = cwd();
 

--- a/t/17-deprecated.t
+++ b/t/17-deprecated.t
@@ -1,0 +1,58 @@
+use Test::Nginx::Socket 'no_plan';
+use Cwd qw(cwd);
+
+my $pwd = cwd();
+
+$ENV{TEST_NGINX_RESOLVER} = '8.8.8.8';
+$ENV{TEST_NGINX_PWD} ||= $pwd;
+$ENV{TEST_COVERAGE} ||= 0;
+
+our $HttpConfig = qq{
+    lua_package_path "$pwd/lib/?.lua;/usr/local/share/lua/5.1/?.lua;;";
+    error_log logs/error.log debug;
+    resolver 8.8.8.8;
+
+    init_by_lua_block {
+        if $ENV{TEST_COVERAGE} == 1 then
+            jit.off()
+            require("luacov.runner").init()
+        end
+    }
+};
+
+no_long_string();
+run_tests();
+
+__DATA__
+=== TEST 1: Old connect syntax still works
+--- http_config eval: $::HttpConfig
+--- config
+    location /a {
+        content_by_lua_block {
+            local http = require "resty.http"
+            local httpc = http.new()
+            local ok, err = httpc:connect("127.0.0.1", ngx.var.server_port)
+            assert(ok, err)
+
+            local res, err = httpc:request{
+                path = "/b"
+            }
+
+            ngx.status = res.status
+            ngx.print(res:read_body())
+
+            httpc:close()
+        }
+    }
+    location = /b {
+        echo "OK";
+    }
+--- request
+GET /a
+--- response_body
+OK
+--- no_error_log
+[error]
+[warn]
+--- error_log
+[debug]


### PR DESCRIPTION
I gave the README a bit of a long overdue overhaul, in the hope that things are much clearer for new users. I also added `WARN` level log statements to the deprecated functions, which could get noisy for some people depending on what they're logging. Any thoughts / opinions on this? 