### PR TITLE
fix(request_uri) use uri host for ssl-server-name

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ When the request is successful, `res` will contain the following fields:
 
 `syntax: res, err = httpc:request_uri(uri, params)`
 
-The single-shot interface (see [usage](#Usage)). Since this method performs an entire end-to-end request, options specified in the `params` can include anything found in both [connect](#connect) and [request](#request) documented above. Note also that fields in `params` will override relevant components of the `uri` if specified.
+The single-shot interface (see [usage](#Usage)). Since this method performs an entire end-to-end request, options specified in the `params` can include anything found in both [connect](#connect) and [request](#request) documented above. Note also that fields `path`, and `query`, in `params` will override relevant components of the `uri` if specified (`scheme`, `host`, and `port` will always be taken from the `uri`).
 
 There are 3 additional parameters for controlling keepalives:
 

--- a/lib/resty/http.lua
+++ b/lib/resty/http.lua
@@ -899,6 +899,7 @@ function _M.request_uri(self, uri, params)
         params.scheme, params.host, params.port, path, query = unpack(parsed_uri)
         params.path = params.path or path
         params.query = params.query or query
+        params.ssl_server_name = params.ssl_server_name or params.host
     end
 
     do


### PR DESCRIPTION
also fixes an incorrect note in the docs

fixes #236