### PR TITLE
chore(*) remove old comment in setclientcert

### DIFF
--- a/lib/resty/http_connect.lua
+++ b/lib/resty/http_connect.lua
@@ -245,7 +245,6 @@ local function connect(self, options)
             ngx_log(ngx_WARN, "cannot use SSL client cert and key without mTLS support")
 
           else
-            -- currently no return value
             ok, err = sock:setclientcert(ssl_client_cert, ssl_client_priv_key)
             if not ok then
               ngx_log(ngx_WARN, "could not set client certificate: ", err)


### PR DESCRIPTION
Now the latest lua-resty-core PR has return `ok, err`,
so the comment is out of date.