### PR TITLE
Change `source.url` in `rockspec` to use `git+https://` instead of `git://` protocol (deprecated by GitHub)

### DIFF
--- a/lua-resty-http-0.17.0.beta.2-0.rockspec
+++ b/lua-resty-http-0.17.0.beta.2-0.rockspec
@@ -1,8 +1,8 @@
 package = "lua-resty-http"
-version = "0.17.0.beta.1-0"
+version = "0.17.0.beta.2-0"
 source = {
-    url = "git://github.com/ledgetech/lua-resty-http",
-    tag = "v0.17.0-beta.1"
+    url = "git+https://github.com/ledgetech/lua-resty-http",
+    tag = "v0.17.0-beta.2"
 }
 description = {
     summary = "Lua HTTP client cosocket driver for OpenResty / ngx_lua.",


### PR DESCRIPTION
GitHub [deprecated usage of `git://` (unencrypted Git protocol) on March 15th, 2022](https://github.blog/changelog/2022-03-15-removed-unencrypted-git-protocol-and-certain-ssh-keys/), so LuaRocks will fail to install any package including a `source.url` starting with `git://`. According to the [LuaRocks documentation](https://github.com/luarocks/luarocks/wiki/Rockspec-format#build-rules), the correct syntax for referencing `https://` URLs is `git+https://`. 

This PR fixes `source.url` in the `.rockspec` file and bumps the version. I checked out the branch from `master`. I will open a second PR backporting the fix to `16.x`.