### PR TITLE
[backport to `v0.16.x`] Change `source.url` in `rockspec` to use `git+https://` instead of `git://` protocol (deprecated by GitHub)

### DIFF
--- a/lua-resty-http-0.16.2-0.rockspec
+++ b/lua-resty-http-0.16.2-0.rockspec
@@ -1,8 +1,8 @@
 package = "lua-resty-http"
-version = "0.16.1-0"
+version = "0.16.2-0"
 source = {
-    url = "git://github.com/ledgetech/lua-resty-http",
-    tag = "v0.16.1"
+    url = "git+https://github.com/ledgetech/lua-resty-http",
+    tag = "v0.16.2"
 }
 description = {
     summary = "Lua HTTP client cosocket driver for OpenResty / ngx_lua.",


### PR DESCRIPTION
This PR is a backport of !270 to the `v0.16.x` "branch" (there is only a tag AFAICT). I created a new branch from the `v0.16.1` tag. I tried to make the GitHub PR target this tag, but apparently you can't target tags, and there is no corresponding branch that I could find to target. So at the moment this PR targets the `master` branch.

Quoting from !270:

> GitHub [deprecated usage of `git://` (unencrypted Git protocol) on March 15th, 2022](https://github.blog/changelog/2022-03-15-removed-unencrypted-git-protocol-and-certain-ssh-keys/), so LuaRocks will fail to install any package including a `source.url` starting with `git://`. According to the [LuaRocks documentation](https://github.com/luarocks/luarocks/wiki/Rockspec-format#build-rules), the correct syntax for referencing `https://` URLs is `git+https://`. 