### PR TITLE
Drain trailer when setting keepalive to avoid "unread data in buffer" error

### DIFF
--- a/lib/resty/http.lua
+++ b/lib/resty/http.lua
@@ -950,6 +950,9 @@ function _M.request_uri(self, uri, params)
         end
 
     else
+        -- drain trailers if needed
+        res:read_trailers()
+
         local ok, err = self:set_keepalive(params.keepalive_timeout, params.keepalive_pool)
         if not ok then
             ngx_log(ngx_ERR, err)


### PR DESCRIPTION
When using request_uri with the response contains trailer, we always
find "unread data in buffer" error because trailers are not read before
set_keepalive.

Signed-off-by: spacewander <spacewanderlzx@gmail.com>