### PR TITLE
Documentation is clearer about using same connection for multiple requests via 'request' function

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,8 @@ When the request is successful, `res` will contain the following fields:
 * `read_body`: A method to read the entire body into a string.
 * `read_trailers`: A method to merge any trailers underneath the headers, after reading the body.
 
+If the response has a body, then before the same connection can be used for another request, you must read the body using `read_body` or `body_reader`.
+
 ## request\_uri
 
 `syntax: res, err = httpc:request_uri(uri, params)`


### PR DESCRIPTION
If a previous HTTP response had a response body, and the body was never read, then a subsequent call to `request` using the same connection will fail. This is because the unread response body will still be sitting in the TCP socket buffers. As a result, when the subsequent call to `request` tries to read the first line of its response to parse out the HTTP version and status code, it will get the first line of the unread response body instead, which will almost certainly not be a valid HTTP status code line.

The documentation was not at all clear about this; make it explicitly state what the user needs to do.