### PR TITLE
fix 100 response with headers

### DIFF
--- a/lib/resty/http.lua
+++ b/lib/resty/http.lua
@@ -646,7 +646,7 @@ local function _handle_continue(sock, body)
             return nil, nil, nil, err
         end
 
-        local ok, err, partial = _send_body(sock, body)
+        local ok, err = _send_body(sock, body)
         if not ok then
             return nil, nil, nil, err
         end

--- a/t/03-requestbody.t
+++ b/t/03-requestbody.t
@@ -164,7 +164,6 @@ c: 3
 [error]
 [warn]
 
-
 === TEST 4: Return non-100 status to user
 --- http_config eval: $::HttpConfig
 --- config
@@ -248,7 +247,6 @@ Expectation Failed
             end
 
             -- with additional header
-            ngx.log(ngx.NOTICE, "before send 100")
             local ok, err = sock:send("HTTP/1.1 100 Continue\r\nConnection: keep-alive\r\n\r\n")
             if not ok then
                 ngx.log(ngx.ERR, "failed to send 100 response: ", err)

--- a/t/03-requestbody.t
+++ b/t/03-requestbody.t
@@ -164,6 +164,7 @@ c: 3
 [error]
 [warn]
 
+
 === TEST 4: Return non-100 status to user
 --- http_config eval: $::HttpConfig
 --- config
@@ -205,7 +206,154 @@ Expectation Failed
 [warn]
 
 
-=== TEST 5: Non string request bodies are converted with correct length
+=== TEST 5: Return 100 Continue with headers
+--- http_config eval: $::HttpConfig
+--- config
+    location = /a {
+        content_by_lua_block {
+            local http = require "resty.http"
+            local httpc = http.new()
+            httpc:connect({
+                scheme = "http",
+                host = "127.0.0.1",
+                port = ngx.var.server_port
+            })
+
+            local res, err = httpc:request{
+                body = "a=1&b=2&c=3",
+                path = "/b",
+                headers = {
+                    ["Expect"] = "100-continue",
+                    ["Content-Type"] = "application/x-www-form-urlencoded",
+                }
+            }
+
+            if not res then
+                ngx.log(ngx.ERR, "httpc:request failed: ", err)
+            end
+
+            ngx.say(res.status)
+            ngx.say(res:read_body())
+            httpc:close()
+        }
+    }
+    location = /b {
+        content_by_lua_block {
+            local len = ngx.req.get_headers()["Content-Length"]
+
+            local sock, err = ngx.req.socket(true)
+            if not sock then
+                ngx.log(ngx.ERR, "server: failed to get raw req socket: ", err)
+                return
+            end
+
+            -- with additional header
+            ngx.log(ngx.NOTICE, "before send 100")
+            local ok, err = sock:send("HTTP/1.1 100 Continue\r\nConnection: keep-alive\r\n\r\n")
+            if not ok then
+                ngx.log(ngx.ERR, "failed to send 100 response: ", err)
+            end
+
+            local data, err = sock:receive(len)
+            if not data then
+                ngx.log(ngx.ERR, "failed to receive: ", err)
+                return
+            end
+
+            local ok, err = sock:send("HTTP/1.1 200 OK\r\n" ..
+                                      "Content-Length: " .. len .. "\r\n" ..
+                                      "Content-Type: application/x-www-form-urlencoded\r\n\r\n" ..
+                                      data)
+            if not ok then
+                ngx.log(ngx.ERR, "failed to send 200 response: ", err)
+                return
+            end
+        }
+    }
+--- request
+GET /a
+--- response_body
+200
+a=1&b=2&c=3
+--- no_error_log
+[error]
+[warn]
+
+
+=== TEST 6: Return 100 Continue without headers
+--- http_config eval: $::HttpConfig
+--- config
+    location = /a {
+        content_by_lua_block {
+            local http = require "resty.http"
+            local httpc = http.new()
+            httpc:connect({
+                scheme = "http",
+                host = "127.0.0.1",
+                port = ngx.var.server_port
+            })
+
+            local res, err = httpc:request{
+                body = "a=1&b=2&c=3",
+                path = "/b",
+                headers = {
+                    ["Expect"] = "100-continue",
+                    ["Content-Type"] = "application/x-www-form-urlencoded",
+                }
+            }
+
+            if not res then
+                ngx.log(ngx.ERR, "httpc:request failed: ", err)
+            end
+
+            ngx.say(res.status)
+            ngx.say(res:read_body())
+            httpc:close()
+        }
+    }
+    location = /b {
+        content_by_lua_block {
+            local len = ngx.req.get_headers()["Content-Length"]
+
+            local sock, err = ngx.req.socket(true)
+            if not sock then
+                ngx.log(ngx.ERR, "server: failed to get raw req socket: ", err)
+                return
+            end
+
+            -- without additional headers
+            local ok, err = sock:send("HTTP/1.1 100 Continue\r\n\r\n")
+            if not ok then
+                ngx.log(ngx.ERR, "failed to send 100 response: ", err)
+            end
+
+            local data, err = sock:receive(len)
+            if not data then
+                ngx.log(ngx.ERR, "failed to receive: ", err)
+                return
+            end
+
+            local ok, err = sock:send("HTTP/1.1 200 OK\r\n" ..
+                                      "Content-Length: " .. len .. "\r\n" ..
+                                      "Content-Type: application/x-www-form-urlencoded\r\n\r\n" ..
+                                      data)
+            if not ok then
+                ngx.log(ngx.ERR, "failed to send 200 response: ", err)
+                return
+            end
+        }
+    }
+--- request
+GET /a
+--- response_body
+200
+a=1&b=2&c=3
+--- no_error_log
+[error]
+[warn]
+
+
+=== TEST 7: Non string request bodies are converted with correct length
 --- http_config eval: $::HttpConfig
 --- config
     location = /a {
@@ -247,7 +395,7 @@ mix123edtable
 [warn]
 
 
-=== TEST 6: Request body as iterator
+=== TEST 8: Request body as iterator
 --- http_config eval: $::HttpConfig
 --- config
     location = /a {
@@ -284,7 +432,7 @@ foobar
 [warn]
 
 
-=== TEST 7: Request body as iterator, errors with missing length
+=== TEST 9: Request body as iterator, errors with missing length
 --- http_config eval: $::HttpConfig
 --- config
     location = /a {
@@ -319,7 +467,7 @@ Request body is a function but a length or chunked encoding is not specified
 [warn]
 
 
-=== TEST 8: Request body as iterator with chunked encoding
+=== TEST 10: Request body as iterator with chunked encoding
 --- http_config eval: $::HttpConfig
 --- config
     location = /a {


### PR DESCRIPTION
The 100 reponse is not processed correctly. After receiving the 100 status line, it only reads a line [here](https://github.com/ledgetech/lua-resty-http/blob/3fc7ced4be20cf012ec97818caf77f90a84e1fa1/lib/resty/http.lua#L643-L646) and assumes there’s no headers. Then it directly tries to receive the status line of the next response [here](https://github.com/ledgetech/lua-resty-http/blob/3fc7ced4be20cf012ec97818caf77f90a84e1fa1/lib/resty/http.lua#L777). If there are headers after 100 statue line, it will fail there.

I checked the [RFC](https://www.rfc-editor.org/rfc/rfc7231) (section 5.2.1 and 6.2.1). Unfortunately, the specification does not explicitly require or prohibit the inclusion of headers in the 100 response. I tested many sites ([httpbin.org](http://httpbin.org/), [mockbin.org](http://mockbin.org/), [hurl.it](http://hurl.it/), webhook.site, [codepunker.com](http://codepunker.com/), [typicode.com](http://typicode.com/)), all of them don’t include any headers. But the squid proxy includes a header of `Connection: keep-alive`. So it’s better to  be compatible with both cases.