### PR TITLE
fix: no trailing "?" for empty query table

### DIFF
--- a/lib/resty/http.lua
+++ b/lib/resty/http.lua
@@ -315,7 +315,6 @@ local function _format_request(self, params)
     if type(query) == "table" then
         query = ngx_encode_args(query)
     end
-    
     if query ~= "" and str_sub(query, 1, 1) ~= "?" then
         query = "?" .. query
     end

--- a/lib/resty/http.lua
+++ b/lib/resty/http.lua
@@ -315,6 +315,7 @@ local function _format_request(self, params)
     if type(query) == "table" then
         query = ngx_encode_args(query)
     end
+
     if query ~= "" and str_sub(query, 1, 1) ~= "?" then
         query = "?" .. query
     end

--- a/lib/resty/http.lua
+++ b/lib/resty/http.lua
@@ -313,8 +313,10 @@ local function _format_request(self, params)
 
     local query = params.query or ""
     if type(query) == "table" then
-        query = "?" .. ngx_encode_args(query)
-    elseif query ~= "" and str_sub(query, 1, 1) ~= "?" then
+        query = ngx_encode_args(query)
+    end
+    
+    if query ~= "" and str_sub(query, 1, 1) ~= "?" then
         query = "?" .. query
     end
 

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -389,3 +389,45 @@ GET /a
 --- no_error_log
 [error]
 [warn]
+
+
+
+=== TEST 14: Empty query
+--- http_config eval: $::HttpConfig
+--- config
+    location = /a {
+        content_by_lua '
+            local http = require "resty.http"
+            local httpc = http.new()
+            httpc:connect{
+                scheme = "http",
+                host = "127.0.0.1",
+                port = ngx.var.server_port
+            }
+
+            local res, err = httpc:request{
+                query = {},
+                path = "/b"
+            }
+
+            ngx.status = res.status
+
+            ngx.print(ngx.header.test)
+
+            httpc:close()
+        ';
+    }
+    location = /b {
+        content_by_lua '
+            ngx.header.test = ngx.var.request_uri
+        ';
+    }
+--- request
+GET /a
+--- response_headers
+/b
+--- no_error_log
+[error]
+[warn]
+
+


### PR DESCRIPTION
When `request` or `request_uri` are called with `param.query` set to an empty table, the result URI would contain a trailing "?".