### PR TITLE
fix poolname to include the digest of the cert for mTLS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,8 @@ jobs:
         openresty_version:
           - 1.17.8.2
           - 1.19.9.1
+          - 1.21.4.3
+          - 1.25.3.1
 
     runs-on: ubuntu-latest
     container:
@@ -49,7 +51,9 @@ jobs:
       run: cpanm -q -n Test::Nginx
 
     - name: Install Luacov
-      run: /usr/local/openresty/luajit/bin/luarocks install luacov
+      run: |
+        /usr/local/openresty/luajit/bin/luarocks install luacov
+        /usr/local/openresty/luajit/bin/luarocks install lua-resty-openssl
 
     - uses: actions/checkout@v2
 

--- a/lib/resty/http_connect.lua
+++ b/lib/resty/http_connect.lua
@@ -167,71 +167,91 @@ local function connect(self, options)
 
     local cert_hash
     if ssl and ssl_client_cert and ssl_client_priv_key then
-        local status, res = xpcall(function()
-            local chain = require("resty.openssl.x509.chain")
-            local x509 = require("resty.openssl.x509")
-            local pkey = require("resty.openssl.pkey")
-            return { chain, x509, pkey }
-        end, debug.traceback)
+        -- fallback to non-mTLS when any error
+        repeat
+            local cert_type = type(ssl_client_cert)
+            local key_type = type(ssl_client_priv_key)
 
-        if status then
-            local chain = res[1]
-            local x509 = res[2]
-            local pkey = res[3]
-
-            if type(ssl_client_cert) ~= "cdata" then
-              return nil, "bad ssl_client_cert: cdata expected, got " .. type(ssl_client_cert)
+            if cert_type ~= "cdata" then
+                ngx_log(ngx_WARN, "bad ssl_client_cert: cdata expected, got " .. cert_type)
+                break
             end
 
-            if type(ssl_client_priv_key) ~= "cdata" then
-              return nil, "bad ssl_client_priv_key: cdata expected, got " .. type(ssl_client_priv_key)
+            if key_type ~= "cdata" then
+                ngx_log(ngx_WARN, "bad ssl_client_priv_key: cdata expected, got " .. key_type)
+                break
             end
 
-            -- convert from `void*` to `OPENSSL_STACK*`
-            local cert_chain, err = chain.dup(ffi_cast("OPENSSL_STACK*", ssl_client_cert))
-            if not cert_chain then
-              return nil, err
-            end
+            local status, res = xpcall(function()
+                local chain = require("resty.openssl.x509.chain")
+                local x509 = require("resty.openssl.x509")
+                local pkey = require("resty.openssl.pkey")
+                return { chain, x509, pkey }
+            end, debug.traceback)
 
-            if #cert_chain < 1 then
-              return nil, "no cert in the chain"
-            end
+            if status then
+                local chain = res[1]
+                local x509 = res[2]
+                local pkey = res[3]
 
-            local cert, err = x509.dup(cert_chain[1].ctx)
-            if not cert then
-              return nil, err
-            end
+                -- convert from `void*` to `OPENSSL_STACK*`
+                local cert_chain, err = chain.dup(ffi_cast("OPENSSL_STACK*", ssl_client_cert))
+                if not cert_chain then
+                    ngx_log(ngx_WARN, "failed to dup the ssl_client_cert, falling back to non-mTLS: " .. err)
+                    break
+                end
 
-            -- convert from `void*` to `EVP_PKEY*`
-            local key, err = pkey.new(ffi_cast("EVP_PKEY*", ssl_client_priv_key))
-            if not key then
-              return nil, err
-            end
-            -- should not free the cdata passed in
-            ffi_gc(key.ctx, nil)
+                if #cert_chain < 1 then
+                    ngx_log(ngx_WARN, "no cert in ssl_client_cert, falling back to non-mTLS: " .. err)
+                    break
+                end
 
-            -- check the private key in order to make sure the caller is indeed the holder of the cert
-            ok, err = cert:check_private_key(key)
-            if not ok then
-              return nil, "failed to match the private key with the certificate: " .. err
-            end
+                local cert, err = x509.dup(cert_chain[1].ctx)
+                if not cert then
+                    ngx_log(ngx_WARN, "failed to dup the x509, falling back to non-mTLS: " .. err)
+                    break
+                end
 
-            cert_hash, err = cert:digest("sha256")
-            if cert_hash then
-              cert_hash = to_hex(cert_hash) -- convert to hex so that it's printable
+                -- convert from `void*` to `EVP_PKEY*`
+                local key, err = pkey.new(ffi_cast("EVP_PKEY*", ssl_client_priv_key))
+                if not key then
+                    ngx_log(ngx_WARN, "failed to new the pkey, falling back to non-mTLS: " .. err)
+                    break
+                end
+                -- should not free the cdata passed in
+                ffi_gc(key.ctx, nil)
+
+                -- check the private key in order to make sure the caller is indeed the holder of the cert
+                ok, err = cert:check_private_key(key)
+                if not ok then
+                    ngx_log(ngx_WARN, "the private key doesn't match the cert, falling back to non-mTLS: " .. err)
+                    break
+                end
+
+                cert_hash, err = cert:digest("sha256")
+                if cert_hash then
+                    cert_hash = to_hex(cert_hash) -- convert to hex so that it's printable
+
+                else
+                    ngx_log(ngx_WARN, "failed to calculate the digest of the cert, falling back to non-mTLS: " .. err)
+                    break
+                end
 
             else
-              return nil, err
-            end
+                if type(res) == "string" and ngx_re_find(res, "module 'resty\\.openssl\\..+' not found") then
+                    ngx_log(ngx_WARN, "can't use mTLS without module `lua-resty-openssl`, falling back to non-mTLS:\n "
+                                      .. res)
 
-        else
-            if type(res) == "string" and ngx_re_find(res, "module 'resty\\.openssl\\..+' not found") then
-                ngx_log(ngx_WARN, "can't use mTLS without module `lua-resty-openssl`, falling back to non-mTLS." .. res)
-
-            else
-                return nil, "failed to load module 'resty.openssl.*':\n" .. res
+                else
+                    ngx_log(ngx_WARN, "failed to load module `resty.openssl.*`, falling back to non-mTLS:\n" .. res)
+                end
             end
-        end
+        until true
+    end
+
+    if not cert_hash then
+        ssl_client_cert = nil
+        ssl_client_priv_key = nil
     end
 
     -- construct a poolname unique within proxy and ssl info

--- a/lib/resty/http_connect.lua
+++ b/lib/resty/http_connect.lua
@@ -166,7 +166,7 @@ local function connect(self, options)
         local proxy_uri_t
         proxy_uri_t, err = self:parse_uri(proxy_uri)
         if not proxy_uri_t then
-            return nil, "uri parse error: ", err
+            return nil, "uri parse error: " .. err
         end
 
         local proxy_scheme = proxy_uri_t[1]
@@ -260,7 +260,7 @@ local function connect(self, options)
         if not ok then
             return nil, "failed to connect to: " .. (proxy_host or "") ..
                         ":" .. (proxy_port or "") ..
-                        ": ", err
+                        ": " .. err
         end
 
         if ssl and sock:getreusedtimes() == 0 then
@@ -280,7 +280,7 @@ local function connect(self, options)
             })
 
             if not res then
-                return nil, "failed to issue CONNECT to proxy:", err
+                return nil, "failed to issue CONNECT to proxy: " .. err
             end
 
             if res.status < 200 or res.status > 299 then

--- a/lib/resty/http_connect.lua
+++ b/lib/resty/http_connect.lua
@@ -192,7 +192,7 @@ local function connect(self, options)
         end
 
         if not openssl_available then
-            return nil, "module `resty.openssl.*` not available, mTLS isn't supported with lua-resty-openssl"
+            return nil, "module `resty.openssl.*` not available, mTLS isn't supported without lua-resty-openssl"
         end
 
         -- convert from `void*` to `OPENSSL_STACK*`

--- a/lib/resty/http_connect.lua
+++ b/lib/resty/http_connect.lua
@@ -244,13 +244,12 @@ local function connect(self, options)
             end
 
             cert_hash, err = cert:digest("sha256")
-            if cert_hash then
-                cert_hash = to_hex(cert_hash) -- convert to hex so that it's printable
-
-            else
+            if not cert_hash then
                 ngx_log(ngx_WARN, "failed to calculate the digest of the cert, falling back to non-mTLS: ", err)
                 break
             end
+
+            cert_hash = to_hex(cert_hash) -- convert to hex so that it's printable
 
         until true
     end
@@ -265,10 +264,10 @@ local function connect(self, options)
         poolname = string_format("%s:%s:%s:%s:%s:%s:%s:%s:%s",
                     request_scheme or "",
                     request_host,
-                    tostring(request_port),
-                    tostring(ssl),
+                    request_port,
+                    ssl,
                     ssl_server_name or "",
-                    tostring(ssl_verify),
+                    ssl_verify,
                     proxy_uri or "",
                     request_scheme == "https" and proxy_authorization or "",
                     cert_hash or "")

--- a/lib/resty/http_connect.lua
+++ b/lib/resty/http_connect.lua
@@ -213,7 +213,7 @@ local function connect(self, options)
         -- convert from `void*` to `EVP_PKEY*`
         local key, err = lib_pkey.new(ffi_cast("EVP_PKEY*", ssl_client_priv_key))
         if not key then
-            return nil, string_format("failed to new the pkey: %s": err)
+            return nil, string_format("failed to new the pkey: %s", err)
         end
         -- should not free the cdata passed in
         ffi_gc(key.ctx, nil)

--- a/lib/resty/http_connect.lua
+++ b/lib/resty/http_connect.lua
@@ -243,6 +243,7 @@ local function connect(self, options)
                    .. ":" .. tostring(ssl_verify)
                    .. ":" .. (proxy_uri or "")
                    .. ":" .. (request_scheme == "https" and proxy_authorization or "")
+                   .. ":" .. (cert_hash or "")
         -- in the above we only add the 'proxy_authorization' as part of the poolname
         -- when the request is https. Because in that case the CONNECT request (which
         -- carries the authorization header) is part of the connect procedure, whereas

--- a/lib/resty/http_connect.lua
+++ b/lib/resty/http_connect.lua
@@ -4,6 +4,7 @@ local ngx_re_sub = ngx.re.sub
 local ngx_re_find = ngx.re.find
 local ngx_log = ngx.log
 local ngx_WARN = ngx.WARN
+local ngx_DEBUG = ngx.DEBUG
 local to_hex = require("resty.string").to_hex
 local ffi_gc = ffi.gc
 local ffi_cast = ffi.cast
@@ -271,6 +272,8 @@ local function connect(self, options)
         -- carries the authorization header) is part of the connect procedure, whereas
         -- with a plain http request the authorization is part of the actual request.
     end
+
+    ngx_log(ngx_DEBUG, "poolname: " .. poolname)
 
     -- do TCP level connection
     local tcp_opts = { pool = poolname, pool_size = pool_size, backlog = backlog }

--- a/lib/resty/http_connect.lua
+++ b/lib/resty/http_connect.lua
@@ -175,84 +175,86 @@ local function connect(self, options)
     end
 
     local cert_hash
-    if ssl and ssl_client_cert and ssl_client_priv_key then
-        -- fallback to non-mTLS when any error
-        repeat
-            local cert_type = type(ssl_client_cert)
-            local key_type = type(ssl_client_priv_key)
+    -- fallback to non-mTLS when any error
+    repeat
+        if not ssl or not ssl_client_cert or not ssl_client_priv_key then
+            break
+        end
 
-            if cert_type ~= "cdata" then
-                ngx_log(ngx_WARN, "bad ssl_client_cert: cdata expected, got ", cert_type)
-                break
+        local cert_type = type(ssl_client_cert)
+        local key_type = type(ssl_client_priv_key)
+
+        if cert_type ~= "cdata" then
+            ngx_log(ngx_WARN, "bad ssl_client_cert: cdata expected, got ", cert_type)
+            break
+        end
+
+        if key_type ~= "cdata" then
+            ngx_log(ngx_WARN, "bad ssl_client_priv_key: cdata expected, got ", key_type)
+            break
+        end
+
+        local status, res = xpcall(require_openssl_libs, debug.traceback)
+
+        if not status then
+            if type(res) == "string" and ngx_re_find(res, "module 'resty\\.openssl\\..+' not found") then
+                ngx_log(ngx_WARN, "can't use mTLS without module `lua-resty-openssl`, falling back to non-mTLS:\n "
+                                , res)
+
+            else
+                ngx_log(ngx_WARN, "failed to load module `resty.openssl.*`, falling back to non-mTLS:\n", res)
             end
 
-            if key_type ~= "cdata" then
-                ngx_log(ngx_WARN, "bad ssl_client_priv_key: cdata expected, got ", key_type)
-                break
-            end
+            break
+        end
 
-            local status, res = xpcall(require_openssl_libs, debug.traceback)
+        local chain = res[1]
+        local x509 = res[2]
+        local pkey = res[3]
 
-            if not status then
-                if type(res) == "string" and ngx_re_find(res, "module 'resty\\.openssl\\..+' not found") then
-                    ngx_log(ngx_WARN, "can't use mTLS without module `lua-resty-openssl`, falling back to non-mTLS:\n "
-                                    , res)
+        -- convert from `void*` to `OPENSSL_STACK*`
+        local cert_chain, err = chain.dup(ffi_cast("OPENSSL_STACK*", ssl_client_cert))
+        if not cert_chain then
+            ngx_log(ngx_WARN, "failed to dup the ssl_client_cert, falling back to non-mTLS: ", err)
+            break
+        end
 
-                else
-                    ngx_log(ngx_WARN, "failed to load module `resty.openssl.*`, falling back to non-mTLS:\n", res)
-                end
+        if #cert_chain < 1 then
+            ngx_log(ngx_WARN, "no cert in ssl_client_cert, falling back to non-mTLS: ", err)
+            break
+        end
 
-                break
-            end
+        local cert, err = x509.dup(cert_chain[1].ctx)
+        if not cert then
+            ngx_log(ngx_WARN, "failed to dup the x509, falling back to non-mTLS: ", err)
+            break
+        end
 
-            local chain = res[1]
-            local x509 = res[2]
-            local pkey = res[3]
+        -- convert from `void*` to `EVP_PKEY*`
+        local key, err = pkey.new(ffi_cast("EVP_PKEY*", ssl_client_priv_key))
+        if not key then
+            ngx_log(ngx_WARN, "failed to new the pkey, falling back to non-mTLS: ", err)
+            break
+        end
+        -- should not free the cdata passed in
+        ffi_gc(key.ctx, nil)
 
-            -- convert from `void*` to `OPENSSL_STACK*`
-            local cert_chain, err = chain.dup(ffi_cast("OPENSSL_STACK*", ssl_client_cert))
-            if not cert_chain then
-                ngx_log(ngx_WARN, "failed to dup the ssl_client_cert, falling back to non-mTLS: ", err)
-                break
-            end
+        -- check the private key in order to make sure the caller is indeed the holder of the cert
+        ok, err = cert:check_private_key(key)
+        if not ok then
+            ngx_log(ngx_WARN, "the private key doesn't match the cert, falling back to non-mTLS: ", err)
+            break
+        end
 
-            if #cert_chain < 1 then
-                ngx_log(ngx_WARN, "no cert in ssl_client_cert, falling back to non-mTLS: ", err)
-                break
-            end
+        cert_hash, err = cert:digest("sha256")
+        if not cert_hash then
+            ngx_log(ngx_WARN, "failed to calculate the digest of the cert, falling back to non-mTLS: ", err)
+            break
+        end
 
-            local cert, err = x509.dup(cert_chain[1].ctx)
-            if not cert then
-                ngx_log(ngx_WARN, "failed to dup the x509, falling back to non-mTLS: ", err)
-                break
-            end
+        cert_hash = to_hex(cert_hash) -- convert to hex so that it's printable
 
-            -- convert from `void*` to `EVP_PKEY*`
-            local key, err = pkey.new(ffi_cast("EVP_PKEY*", ssl_client_priv_key))
-            if not key then
-                ngx_log(ngx_WARN, "failed to new the pkey, falling back to non-mTLS: ", err)
-                break
-            end
-            -- should not free the cdata passed in
-            ffi_gc(key.ctx, nil)
-
-            -- check the private key in order to make sure the caller is indeed the holder of the cert
-            ok, err = cert:check_private_key(key)
-            if not ok then
-                ngx_log(ngx_WARN, "the private key doesn't match the cert, falling back to non-mTLS: ", err)
-                break
-            end
-
-            cert_hash, err = cert:digest("sha256")
-            if not cert_hash then
-                ngx_log(ngx_WARN, "failed to calculate the digest of the cert, falling back to non-mTLS: ", err)
-                break
-            end
-
-            cert_hash = to_hex(cert_hash) -- convert to hex so that it's printable
-
-        until true
-    end
+    until true
 
     if not cert_hash then
         ssl_client_cert = nil

--- a/lib/resty/http_connect.lua
+++ b/lib/resty/http_connect.lua
@@ -179,6 +179,13 @@ local function connect(self, options)
             local x509 = res[2]
             local pkey = res[3]
 
+            if type(ssl_client_cert) ~= "cdata" then
+              return nil, "bad ssl_client_cert: cdata expected, got " .. type(ssl_client_cert)
+            end
+
+            if type(ssl_client_priv_key) ~= "cdata" then
+              return nil, "bad ssl_client_priv_key: cdata expected, got " .. type(ssl_client_priv_key)
+            end
 
             -- convert from `void*` to `OPENSSL_STACK*`
             local cert_chain, err = chain.dup(ffi_cast("OPENSSL_STACK*", ssl_client_cert))

--- a/lib/resty/http_connect.lua
+++ b/lib/resty/http_connect.lua
@@ -19,7 +19,7 @@ local openssl_available, res = xpcall(function()
 end, debug.traceback)
 
 if not openssl_available then
-  ngx_log(ngx_WARN, "failed to load module `resty.openssl.*`, mTLS isn't supported without lua-resty-openssl :\n", res)
+  ngx_log(ngx_WARN, "failed to load module `resty.openssl.*`, mTLS isn't supported without lua-resty-openssl:\n", res)
 end
 
 --[[

--- a/t/20-mtls.t
+++ b/t/20-mtls.t
@@ -139,7 +139,7 @@ location /t {
           ngx.say(res:read_body())
 
         else
-          ngx.say("failed to connect: " .. err or "")
+          ngx.say('failed to connect: ' .. (err or ''))
         end
 
         httpc:close()
@@ -157,6 +157,7 @@ GET /t
 failed to connect: bad ssl_client_priv_key: cdata expected, got string
 --- skip_nginx
 4: < 1.21.4
+
 
 === TEST 3: Connection succeeds with client cert and key.
 --- http_config eval: $::mtls_http_config

--- a/t/20-mtls.t
+++ b/t/20-mtls.t
@@ -137,6 +137,9 @@ location /t {
           })
 
           ngx.say(res:read_body())
+
+        else
+          ngx.say("failed to connect: " .. err or "")
         end
 
         httpc:close()
@@ -147,13 +150,15 @@ location /t {
 --- request
 GET /t
 --- error_code: 200
---- error_log
-bad ssl_client_priv_key: cdata expected, got string
---- response_body_unlike: hello, CN=foo@example.com,O=OpenResty,ST=California,C=US
+--- no_error_log
+[error]
+[warn]
+--- response_body
+failed to connect: bad ssl_client_priv_key: cdata expected, got string
 --- skip_nginx
 4: < 1.21.4
 
-=== TEST 3: Connection succeeds with client cert and key. SKIP'd for CI until feature is merged.
+=== TEST 3: Connection succeeds with client cert and key.
 --- http_config eval: $::mtls_http_config
 --- config eval
 "

--- a/t/20-mtls.t
+++ b/t/20-mtls.t
@@ -105,7 +105,6 @@ GET /t
 
 === TEST 2: Connection fails during handshake with not priv_key
 --- http_config eval: $::mtls_http_config
---- SKIP
 --- config eval
 "
 lua_ssl_trusted_certificate $::HtmlDir/test.crt;
@@ -151,10 +150,10 @@ GET /t
 --- error_log
 could not set client certificate: bad client pkey type
 --- response_body_unlike: hello, CN=foo@example.com,O=OpenResty,ST=California,C=US
-
+--- skip_nginx
+4: < 1.21.4
 
 === TEST 3: Connection succeeds with client cert and key. SKIP'd for CI until feature is merged.
---- SKIP
 --- http_config eval: $::mtls_http_config
 --- config eval
 "
@@ -208,10 +207,10 @@ GET /t
 [warn]
 --- response_body
 hello, CN=foo@example.com,O=OpenResty,ST=California,C=US
-
+--- skip_nginx
+4: < 1.21.4
 
 === TEST 4: users with different client certs should not share the same pool.
---- SKIP
 --- http_config eval: $::mtls_http_config
 --- config eval
 "
@@ -307,3 +306,5 @@ hello, CN=foo@example.com,O=OpenResty,ST=California,C=US
 true
 nil
 400
+--- skip_nginx
+4: < 1.21.4

--- a/t/20-mtls.t
+++ b/t/20-mtls.t
@@ -148,7 +148,7 @@ location /t {
 GET /t
 --- error_code: 200
 --- error_log
-could not set client certificate: bad client pkey type
+bad ssl_client_priv_key: cdata expected, got string
 --- response_body_unlike: hello, CN=foo@example.com,O=OpenResty,ST=California,C=US
 --- skip_nginx
 4: < 1.21.4


### PR DESCRIPTION
Fix https://github.com/ledgetech/lua-resty-http/issues/306

Additionally, add the latest openresty versions in CI. OpenResty has already supported `tcpsock:setclientcert` from 1.21.4.2 so only skip the mtls tests when version < 1.21.4