### PR TITLE
fix(body-reader): do not call sock:receive for reading 0 bytes

### DIFF
--- a/lib/resty/http.lua
+++ b/lib/resty/http.lua
@@ -522,6 +522,9 @@ local function _body_reader(sock, content_length, default_chunk_size)
 
         elseif not max_chunk_size then
             -- We have a length and potentially keep-alive, but want everything.
+            if content_length == 0 then
+                co_yield("")
+            end
             co_yield(sock:receive(content_length))
 
         else

--- a/lib/resty/http.lua
+++ b/lib/resty/http.lua
@@ -524,8 +524,9 @@ local function _body_reader(sock, content_length, default_chunk_size)
             -- We have a length and potentially keep-alive, but want everything.
             if content_length == 0 then
                 co_yield("")
+            else
+                co_yield(sock:receive(content_length))
             end
-            co_yield(sock:receive(content_length))
 
         else
             -- We have a length and potentially a keep-alive, and wish to stream


### PR DESCRIPTION
Some sockets can block if called to read 0 bytes until actual bytes are available to read.