### PR TITLE
Don't log poolname

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ The options table has the following fields:
 * `host`: target host, or path to a unix domain socket
 * `port`: port on target host, will default to `80` or `443` based on the scheme
 * `pool`: custom connection pool name. Option as per [OpenResty docs](https://github.com/openresty/lua-nginx-module#tcpsockconnect), except that the default will become a pool name constructed using the SSL / proxy properties, which is important for safe connection reuse. When in doubt, leave it blank!
+* `pool_debug`: set to `true` to log the connection pool name at `DEBUG` level, off by default
 * `pool_size`: option as per [OpenResty docs](https://github.com/openresty/lua-nginx-module#tcpsockconnect)
 * `backlog`: option as per [OpenResty docs](https://github.com/openresty/lua-nginx-module#tcpsockconnect)
 * `proxy_opts`: sub-table, defaults to the global proxy options set, see [set\_proxy\_options](#set_proxy_options).

--- a/lib/resty/http_connect.lua
+++ b/lib/resty/http_connect.lua
@@ -4,7 +4,6 @@ local ngx_re_sub = ngx.re.sub
 local ngx_re_find = ngx.re.find
 local ngx_log = ngx.log
 local ngx_WARN = ngx.WARN
-local ngx_DEBUG = ngx.DEBUG
 local to_hex = require("resty.string").to_hex
 local ffi_gc = ffi.gc
 local ffi_cast = ffi.cast
@@ -249,8 +248,6 @@ local function connect(self, options)
         -- carries the authorization header) is part of the connect procedure, whereas
         -- with a plain http request the authorization is part of the actual request.
     end
-
-    ngx_log(ngx_DEBUG, "poolname: ", poolname)
 
     -- do TCP level connection
     local tcp_opts = { pool = poolname, pool_size = pool_size, backlog = backlog }

--- a/lib/resty/http_connect.lua
+++ b/lib/resty/http_connect.lua
@@ -38,6 +38,7 @@ client:connect {
     host = "myhost.com",    -- target machine, or a unix domain socket
     port = nil,             -- port on target machine, will default to 80/443 based on scheme
     pool = nil,             -- connection pool name, leave blank! this function knows best!
+    pool_debug = nil,       -- set to 'true' to log the connection pool name at DEBUG level
     pool_size = nil,        -- options as per: https://github.com/openresty/lua-nginx-module#tcpsockconnect
     backlog = nil,
 
@@ -250,7 +251,9 @@ local function connect(self, options)
         -- with a plain http request the authorization is part of the actual request.
     end
 
-    ngx_log(ngx_DEBUG, "poolname: ", poolname)
+    if options.pool_debug == true then
+        ngx_log(ngx_DEBUG, "poolname: ", poolname)
+    end
 
     -- do TCP level connection
     local tcp_opts = { pool = poolname, pool_size = pool_size, backlog = backlog }


### PR DESCRIPTION
Remove unconditional logging of poolname (added in #307). It's polluting logs, and OpenResty doesn't have fine-grained log filtering.

If you want to keep this - how about logging it when an undocumented `_debug` flag is set? It would be set to the value of the internal `DEBUG` variable from http.lua.