### PR TITLE
Refactor request handling for better code reuse

### DIFF
--- a/lib/resty/http.lua
+++ b/lib/resty/http.lua
@@ -903,8 +903,7 @@ function _M.request_pipeline(self, requests)
     return responses
 end
 
-
-function _M.request_uri(self, uri, params)
+function _M.prepare_request_params(self, uri, params)
     params = tbl_copy(params or {}) -- Take by value
     if self.proxy_opts then
         params.proxy_opts = tbl_copy(self.proxy_opts or {})
@@ -929,6 +928,15 @@ function _M.request_uri(self, uri, params)
             params.proxy_opts.https_proxy_authorization = proxy_auth
             params.proxy_opts.http_proxy_authorization = proxy_auth
         end
+    end
+
+    return params
+end
+
+function _M.request_uri(self, uri, params)
+    local params, err = self:prepare_request_params(uri, params)
+    if not params then
+        return nil, err
     end
 
     local ok, err = self:connect(params)


### PR DESCRIPTION
Hello, There might be cases that doing request_uri without read the whole body (for example, better support for AI chat application sse proxy)