### PR TITLE
fix: Close connection when set keepalive failed

### DIFF
--- a/lib/resty/http.lua
+++ b/lib/resty/http.lua
@@ -959,6 +959,7 @@ function _M.request_uri(self, uri, params)
     else
         local ok, err = self:set_keepalive(params.keepalive_timeout, params.keepalive_pool)
         if not ok then
+            self:close()
             ngx_log(ngx_ERR, err)
         end
 


### PR DESCRIPTION
When the server incorrectly returns a Content-Length value smaller than the actual data length, reading the data based on the declared length will inevitably leave unread data in the buffer. This results in a failure to set up keepalive for connection reuse. According to the source code of request_uri, such keepalive failures are not explicitly returned to the caller. In this scenario, the best approach is to ​proactively close the connection to prevent resource leaks.