### PR TITLE
fix: when EXPECTING_BODY nil will hand request

### DIFF
--- a/lib/resty/http.lua
+++ b/lib/resty/http.lua
@@ -706,7 +706,7 @@ function _M.send_request(self, params)
                 headers["Content-Length"] = length
 
             elseif body == nil and EXPECTING_BODY[str_upper(params.method)] then
-                headers["Content-Length"] = 0
+                return nil, "Request body is nil but " .. str_upper(params.method) .. " method expects a body. Use an empty string \"\" if you want to send an empty body."
 
             elseif body ~= nil then
                 headers["Content-Length"] = #tostring(body)


### PR DESCRIPTION
### summy

This pull request updates the behavior of the HTTP library to handle cases where the request body is `nil` for methods that expect a body (e.g., POST, PUT, PATCH). It introduces an error message for such cases and adjusts the corresponding tests to align with the new behavior.

### Related issues

closed https://github.com/ledgetech/lua-resty-http/issues/331

### Changes to HTTP request handling:

* [`lib/resty/http.lua`](diffhunk://#diff-5a69f35c0415b018379ba287ca560aedd2f303172dec16f38a873aa51811a416L709-R709): Updated the `_M.send_request` function to return an error when the request body is `nil` for methods that expect a body. The error message advises using an empty string (`""`) if an empty body is intended.

### Changes to tests:

* [`t/06-simpleinterface.t`](diffhunk://#diff-ea61774d2a82c00539d612e02177df9c1f0b09d4f2b9218d6fa18dc15f7d6a8eL272-R280): Modified test 7 to explicitly set the request body to an empty string (`""`) for POST, PUT, and PATCH requests, ensuring the `Content-Length` header is correctly set.
* [`t/06-simpleinterface.t`](diffhunk://#diff-ea61774d2a82c00539d612e02177df9c1f0b09d4f2b9218d6fa18dc15f7d6a8eR339-R372): Added a new test (test 9) to verify that an error is returned when the request body is `nil` for POST, PUT, and PATCH requests. This test confirms the new behavior and validates the error messages.