### PR TITLE
optimize: avoid pcall when validating the Connection response header

### DIFF
--- a/lib/resty/http.lua
+++ b/lib/resty/http.lua
@@ -794,8 +794,9 @@ function _M.read_response(self, params)
     end
 
     -- keepalive is true by default. Determine if this is correct or not.
-    local ok, connection = pcall(str_lower, res_headers["Connection"])
-    if ok then
+    local connection = res_headers["Connection"]
+    if connection ~= nil then
+        connection = str_lower(connection)
         if (version == 1.1 and str_find(connection, "close", 1, true)) or
            (version == 1.0 and not str_find(connection, "keep-alive", 1, true)) then
             self.keepalive = false

--- a/lib/resty/http.lua
+++ b/lib/resty/http.lua
@@ -798,15 +798,16 @@ function _M.read_response(self, params)
     end
 
     -- keepalive is true by default. Determine if this is correct or not.
-    local ok, connection = pcall(str_lower, res_headers["Connection"])
-    if ok then
-        if (version == 1.1 and str_find(connection, "close", 1, true)) or
-           (version == 1.0 and not str_find(connection, "keep-alive", 1, true)) then
+    local connection = res_headers["Connection"]
+    if type(connection) ~= "string" then
+        -- no connection header (or duplicated as a table)
+        if version == 1.0 then
             self.keepalive = false
         end
     else
-        -- no connection header
-        if version == 1.0 then
+        connection = str_lower(connection)
+        if (version == 1.1 and str_find(connection, "close", 1, true)) or
+           (version == 1.0 and not str_find(connection, "keep-alive", 1, true)) then
             self.keepalive = false
         end
     end


### PR DESCRIPTION
Previously the Connection header was lowercased via pcall(str_lower, ...)
to tolerate a nil header, but pcall carries non-trivial overhead on the
hot response path.

Check the header type directly instead: only lowercase and parse it when
it is a string. A nil header (no Connection) or a table (duplicated
header) falls back to the default keepalive handling, matching the
previous pcall behaviour.