### PR TITLE
feature: add timer context support for get_client_body_reader.

### DIFF
--- a/lib/resty/http.lua
+++ b/lib/resty/http.lua
@@ -974,7 +974,7 @@ function _M.request_uri(self, uri, params)
 end
 
 
-function _M.get_client_body_reader(_, chunksize, sock)
+function _M.get_client_body_reader(_, chunksize, sock, headers)
     chunksize = chunksize or 65536
 
     if not sock then
@@ -994,8 +994,11 @@ function _M.get_client_body_reader(_, chunksize, sock)
         end
     end
 
-    local headers = ngx_req_get_headers()
-    local length = headers.content_length
+    if not headers then
+        headers = ngx_req_get_headers()
+    end
+
+    local length = headers["Content-Length"]
     if length then
         return _body_reader(sock, tonumber(length), chunksize)
     elseif transfer_encoding_is_chunked(headers) then

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -24,6 +24,7 @@ no_long_string();
 run_tests();
 
 __DATA__
+
 === TEST 1: Simple default get.
 --- http_config eval: $::HttpConfig
 --- config
@@ -57,6 +58,7 @@ OK
 --- no_error_log
 [error]
 [warn]
+
 
 
 === TEST 2: HTTP 1.0
@@ -93,6 +95,7 @@ OK
 --- no_error_log
 [error]
 [warn]
+
 
 
 === TEST 3: Status code and reason phrase
@@ -136,6 +139,7 @@ OK
 [warn]
 
 
+
 === TEST 4: Response headers
 --- http_config eval: $::HttpConfig
 --- config
@@ -172,6 +176,7 @@ x-value
 --- no_error_log
 [error]
 [warn]
+
 
 
 === TEST 5: Query
@@ -223,7 +228,8 @@ X-Header-B: 2
 [warn]
 
 
-=== TEST 7: HEAD has no body.
+
+=== TEST 6: HEAD has no body.
 --- http_config eval: $::HttpConfig
 --- config
     location = /a {
@@ -260,7 +266,8 @@ GET /a
 [warn]
 
 
-=== TEST 8: Errors when not initialized
+
+=== TEST 7: Errors when not initialized
 --- http_config eval: $::HttpConfig
 --- config
     location = /a {
@@ -300,7 +307,8 @@ not initialized
 [warn]
 
 
-=== TEST 12: Allow empty HTTP header values (RFC7230)
+
+=== TEST 8: Allow empty HTTP header values (RFC7230)
 --- http_config eval: $::HttpConfig
 --- config
     location = /a {
@@ -342,7 +350,9 @@ OK
 [error]
 [warn]
 
-=== TEST 13: Should return error on invalid HTTP version in response status line
+
+
+=== TEST 9: Should return error on invalid HTTP version in response status line
 --- http_config eval: $::HttpConfig
 --- config
     location = /a {
@@ -366,7 +376,9 @@ GET /a
 [error]
 [warn]
 
-=== TEST 14: Should return error on invalid status code in response status line
+
+
+=== TEST 10: Should return error on invalid status code in response status line
 --- http_config eval: $::HttpConfig
 --- config
     location = /a {
@@ -392,7 +404,7 @@ GET /a
 
 
 
-=== TEST 14: Empty query
+=== TEST 11: Empty query
 --- http_config eval: $::HttpConfig
 --- config
     location = /a {
@@ -429,5 +441,3 @@ GET /a
 --- no_error_log
 [error]
 [warn]
-
-

--- a/t/02-chunked.t
+++ b/t/02-chunked.t
@@ -24,6 +24,7 @@ no_long_string();
 run_tests();
 
 __DATA__
+
 === TEST 1: Non chunked.
 --- http_config eval: $::HttpConfig
 --- config
@@ -65,6 +66,7 @@ GET /a
 --- no_error_log
 [error]
 [warn]
+
 
 
 === TEST 2: Chunked. The number of chunks received when no max size is given proves the response was in fact chunked.
@@ -127,6 +129,7 @@ GET /a
 [warn]
 
 
+
 === TEST 3: Chunked using read_body method.
 --- http_config eval: $::HttpConfig
 --- config
@@ -173,6 +176,7 @@ GET /a
 --- no_error_log
 [error]
 [warn]
+
 
 
 === TEST 4: Chunked. multiple-headers, mixed case
@@ -240,6 +244,7 @@ table
 [warn]
 
 
+
 === TEST 5: transfer_encoding_is_chunked utility.
 --- http_config eval: $::HttpConfig
 --- config
@@ -275,6 +280,7 @@ GET /a
 --- no_error_log
 [error]
 [warn]
+
 
 
 === TEST 6: Don't send Content-Length if Transfer-Encoding is specified

--- a/t/03-requestbody.t
+++ b/t/03-requestbody.t
@@ -24,6 +24,7 @@ no_long_string();
 run_tests();
 
 __DATA__
+
 === TEST 1: POST form-urlencoded
 --- http_config eval: $::HttpConfig
 --- config
@@ -67,6 +68,7 @@ c: 3
 --- no_error_log
 [error]
 [warn]
+
 
 
 === TEST 2: POST form-urlencoded 1.0
@@ -118,6 +120,7 @@ c: 3
 [warn]
 
 
+
 === TEST 3: 100 Continue does not end requset
 --- http_config eval: $::HttpConfig
 --- config
@@ -164,6 +167,8 @@ c: 3
 [error]
 [warn]
 
+
+
 === TEST 4: Return non-100 status to user
 --- http_config eval: $::HttpConfig
 --- config
@@ -203,6 +208,7 @@ Expectation Failed
 --- no_error_log
 [error]
 [warn]
+
 
 
 === TEST 5: Return 100 Continue with headers
@@ -278,6 +284,7 @@ a=1&b=2&c=3
 [warn]
 
 
+
 === TEST 6: Return 100 Continue without headers
 --- http_config eval: $::HttpConfig
 --- config
@@ -351,6 +358,7 @@ a=1&b=2&c=3
 [warn]
 
 
+
 === TEST 7: Non string request bodies are converted with correct length
 --- http_config eval: $::HttpConfig
 --- config
@@ -393,6 +401,7 @@ mix123edtable
 [warn]
 
 
+
 === TEST 8: Request body as iterator
 --- http_config eval: $::HttpConfig
 --- config
@@ -430,6 +439,7 @@ foobar
 [warn]
 
 
+
 === TEST 9: Request body as iterator, errors with missing length
 --- http_config eval: $::HttpConfig
 --- config
@@ -463,6 +473,7 @@ Request body is a function but a length or chunked encoding is not specified
 --- no_error_log
 [error]
 [warn]
+
 
 
 === TEST 10: Request body as iterator with chunked encoding

--- a/t/04-trailers.t
+++ b/t/04-trailers.t
@@ -24,6 +24,7 @@ no_long_string();
 run_tests();
 
 __DATA__
+
 === TEST 1: Trailers. Check Content-MD5 generated after the body is sent matches up.
 --- http_config eval: $::HttpConfig
 --- config
@@ -94,6 +95,7 @@ OK
 --- no_error_log
 [error]
 [warn]
+
 
 
 === TEST 2: Advertised trailer does not exist, handled gracefully.

--- a/t/05-stream.t
+++ b/t/05-stream.t
@@ -24,6 +24,7 @@ no_long_string();
 run_tests();
 
 __DATA__
+
 === TEST 1: Chunked streaming body reader returns the right content length.
 --- http_config eval: $::HttpConfig
 --- config
@@ -74,6 +75,7 @@ chunked
 --- no_error_log
 [error]
 [warn]
+
 
 
 === TEST 2: Non-Chunked streaming body reader returns the right content length.
@@ -131,7 +133,8 @@ nil
 [warn]
 
 
-=== TEST 2b: Non-Chunked streaming body reader, buffer size becomes nil
+
+=== TEST 3b: Non-Chunked streaming body reader, buffer size becomes nil
 --- http_config eval: $::HttpConfig
 --- config
     location = /a {
@@ -184,7 +187,8 @@ nil
 Buffer size not specified, bailing
 
 
-=== TEST 3: HTTP 1.0 body reader with no max size returns the right content length.
+
+=== TEST 4: HTTP 1.0 body reader with no max size returns the right content length.
 --- http_config eval: $::HttpConfig
 --- config
     location = /a {
@@ -240,7 +244,8 @@ nil
 [warn]
 
 
-=== TEST 4: HTTP 1.0 body reader with max chunk size returns the right content length.
+
+=== TEST 5: HTTP 1.0 body reader with max chunk size returns the right content length.
 --- http_config eval: $::HttpConfig
 --- config
     location = /a {
@@ -298,7 +303,8 @@ nil
 [warn]
 
 
-=== TEST 4b: HTTP 1.0 body reader with no content length, stream works as expected.
+
+=== TEST 6b: HTTP 1.0 body reader with no content length, stream works as expected.
 --- http_config eval: $::HttpConfig
 --- config
     location = /a {
@@ -365,7 +371,8 @@ GET /a
 [warn]
 
 
-=== TEST 5: Chunked streaming body reader with max chunk size returns the right content length.
+
+=== TEST 7: Chunked streaming body reader with max chunk size returns the right content length.
 --- http_config eval: $::HttpConfig
 --- config
     location = /a {
@@ -421,7 +428,8 @@ chunked
 [warn]
 
 
-=== TEST 6: Request reader correctly reads body
+
+=== TEST 8: Request reader correctly reads body
 --- http_config eval: $::HttpConfig
 --- config
     location = /a {
@@ -450,7 +458,9 @@ foobarbazfoobarbazfoobarbazfoobarbazfoobarbazfoobarbazfoobarbazfoobarbazfoobarba
 [error]
 [warn]
 
-=== TEST 7: Request reader correctly reads body in chunks
+
+
+=== TEST 9: Request reader correctly reads body in chunks
 --- http_config eval: $::HttpConfig
 --- config
     location = /a {
@@ -484,7 +494,8 @@ foobarbazfoobarbazfoobarbazfoobarbazfoobarbazfoobarbazfoobarbazfoobarbazfoobarba
 [warn]
 
 
-=== TEST 8: Request reader passes into client
+
+=== TEST 10: Request reader passes into client
 --- http_config eval: $::HttpConfig
 --- config
     location = /a {
@@ -532,7 +543,8 @@ foobarbazfoobarbazfoobarbazfoobarbazfoobarbazfoobarbazfoobarbazfoobarbazfoobarba
 [warn]
 
 
-=== TEST 9: Body reader is a function returning nil when no body is present.
+
+=== TEST 11: Body reader is a function returning nil when no body is present.
 --- http_config eval: $::HttpConfig
 --- config
     location = /a {
@@ -569,7 +581,8 @@ GET /a
 [warn]
 
 
-=== TEST 10: Issue a notice (but do not error) if trying to read the request body in a subrequest
+
+=== TEST 12: Issue a notice (but do not error) if trying to read the request body in a subrequest
 --- http_config eval: $::HttpConfig
 --- config
     location = /a {

--- a/t/06-simpleinterface.t
+++ b/t/06-simpleinterface.t
@@ -24,6 +24,7 @@ no_long_string();
 run_tests();
 
 __DATA__
+
 === TEST 1: Simple URI interface
 --- http_config eval: $::HttpConfig
 --- config
@@ -64,6 +65,7 @@ OK
 [warn]
 
 
+
 === TEST 2: Simple URI interface HTTP 1.0
 --- http_config eval: $::HttpConfig
 --- config
@@ -102,6 +104,7 @@ OK
 --- no_error_log
 [error]
 [warn]
+
 
 
 === TEST 3 Simple URI interface, params override
@@ -149,6 +152,7 @@ OK
 [warn]
 
 
+
 === TEST 4 Simple URI interface, params override, query as string
 --- http_config eval: $::HttpConfig
 --- config
@@ -191,6 +195,7 @@ OK
 [warn]
 
 
+
 === TEST 5 Simple URI interface, params override, query as string, as leading ?
 --- http_config eval: $::HttpConfig
 --- config
@@ -231,6 +236,8 @@ OK
 [error]
 [warn]
 
+
+
 === TEST 6: Connection is closed on error
 --- http_config eval: $::HttpConfig
 --- config
@@ -267,6 +274,7 @@ GET /a
 nil closed
 --- error_log
 lua tcp socket read timed out
+
 
 
 === TEST 7: Content-Length is set on POST/PUT/PATCH requests when body is explicitly empty
@@ -307,6 +315,7 @@ PATCH Content-Length: 0
 [warn]
 
 
+
 === TEST 8: Content-Length is not set on GET requests when body is absent
 --- http_config eval: $::HttpConfig
 --- config
@@ -335,6 +344,7 @@ Content-Length: nil
 --- no_error_log
 [error]
 [warn]
+
 
 
 === TEST 9: Error when body is nil for POST/PUT/PATCH requests

--- a/t/07-keepalive.t
+++ b/t/07-keepalive.t
@@ -24,6 +24,7 @@ no_long_string();
 run_tests();
 
 __DATA__
+
 === TEST 1 Simple interface, Connection: Keep-alive. Test the connection is reused.
 --- http_config eval: $::HttpConfig
 --- config
@@ -57,6 +58,7 @@ keep-alive
 --- no_error_log
 [error]
 [warn]
+
 
 
 === TEST 2 Simple interface, Connection: close, test we don't try to keepalive, but also that subsequent connections can keepalive.
@@ -107,6 +109,7 @@ GET /a
 [warn]
 
 
+
 === TEST 3 Generic interface, Connection: Keep-alive. Test the connection is reused.
 --- http_config eval: $::HttpConfig
 --- config
@@ -151,6 +154,7 @@ keep-alive
 --- no_error_log
 [error]
 [warn]
+
 
 
 === TEST 4 Generic interface, Connection: Close. Test we don't try to keepalive, but also that subsequent connections can keepalive.
@@ -214,6 +218,7 @@ connection must be closed
 --- no_error_log
 [error]
 [warn]
+
 
 
 === TEST 5: Generic interface, HTTP 1.0, no connection header. Test we don't try to keepalive, but also that subsequent connections can keepalive.
@@ -284,6 +289,8 @@ connection must be closed
 --- no_error_log
 [error]
 [warn]
+
+
 
 === TEST 6: Simple interface, override settings
 --- http_config eval: $::HttpConfig
@@ -363,6 +370,8 @@ keep-alive
 --- no_error_log
 [error]
 [warn]
+
+
 
 === TEST 7: Generic interface, HTTP 1.1, Connection: Upgrade, close. Test we don't try to keepalive, but also that subsequent connections can keepalive.
 --- http_config eval: $::HttpConfig

--- a/t/08-pipeline.t
+++ b/t/08-pipeline.t
@@ -24,6 +24,7 @@ no_long_string();
 run_tests();
 
 __DATA__
+
 === TEST 1 Test that pipelined requests can be read correctly.
 --- http_config eval: $::HttpConfig
 --- config
@@ -94,6 +95,7 @@ D
 --- no_error_log
 [error]
 [warn]
+
 
 
 === TEST 2: Test we can handle timeouts on reading the pipelined requests.

--- a/t/09-ssl.t
+++ b/t/09-ssl.t
@@ -24,6 +24,7 @@ no_long_string();
 run_tests();
 
 __DATA__
+
 === TEST 1: parse_uri returns port 443 for https URIs
 --- http_config eval: $::HttpConfig
 --- config
@@ -42,6 +43,7 @@ GET /a
 --- no_error_log
 [error]
 [warn]
+
 
 
 === TEST 2: parse_uri returns port 80 for http URIs

--- a/t/10-clientbodyreader.t
+++ b/t/10-clientbodyreader.t
@@ -10,6 +10,8 @@ our $HttpConfig = qq{
     lua_package_path "$pwd/lib/?.lua;/usr/local/share/lua/5.1/?.lua;;";
     error_log logs/error.log debug;
 
+    lua_shared_dict test_dict 1m;
+
     init_by_lua_block {
         if $ENV{TEST_COVERAGE} == 1 then
             jit.off()
@@ -24,6 +26,7 @@ no_long_string();
 run_tests();
 
 __DATA__
+
 === TEST 1: Issue a notice (but do not error) if trying to read the request body in a subrequest
 --- http_config eval: $::HttpConfig
 --- config
@@ -65,6 +68,7 @@ OK
 [warn]
 
 
+
 === TEST 2: Read request body
 --- http_config eval: $::HttpConfig
 --- config
@@ -95,7 +99,8 @@ foobar
 [warn]
 
 
-=== TEST 2: Read chunked request body, errors as not yet supported
+
+=== TEST 3: Read chunked request body, errors as not yet supported
 --- http_config eval: $::HttpConfig
 --- config
     location = /a {
@@ -119,4 +124,192 @@ bar\r
 --- error_log
 chunked request bodies not supported yet
 --- no_error_log
+[warn]
+
+
+
+=== TEST 4: Read a body in a timer context with explicitly provided socket and headers(1 byte buffer)
+--- http_config eval: $::HttpConfig
+--- config
+    location = /b {
+        content_by_lua_block {
+            ngx.header["Content-Length"] = 3
+            ngx.print("foo")
+        }
+    }
+
+    location = /a {
+        content_by_lua_block {
+            -- ngx.var / ngx.req.* are not available inside a timer, so
+            -- capture what we need and pass it in explicitly.
+            local port = ngx.var.server_port
+
+            local function handler(premature, port)
+                local sock = ngx.socket.tcp()
+                local ok, err = sock:connect("127.0.0.1", port)
+                if not ok then
+                    ngx.shared.test_dict:set("body", "connect failed: " .. err)
+                    return
+                end
+
+                sock:send("GET /b HTTP/1.0\r\nHost: localhost\r\n\r\n")
+
+                -- Read the status line and response headers off the socket.
+                local content_length
+                while true do
+                    local line = sock:receive("*l")
+                    if not line or line == "" then
+                        break
+                    end
+                    local k, v = line:match("^([^:]+):%s*(.+)$")
+                    if k and k:lower() == "content-length" then
+                        content_length = tonumber(v)
+                    end
+                end
+
+                -- Use the explicit socket + headers overloads since
+                -- ngx.req.socket() / ngx.req.get_headers() do not work here.
+                local httpc = require("resty.http").new()
+                local headers = { ["Content-Length"] = content_length }
+                local reader, err = httpc:get_client_body_reader(1, sock, headers)
+                if not reader then
+                    ngx.shared.test_dict:set("body", "no reader: " .. (err or "nil"))
+                    return
+                end
+
+                local body = {}
+                repeat
+                    local buffer, err = reader()
+                    if err then
+                        ngx.shared.test_dict:set("body", "read error: " .. err)
+                        return
+                    end
+                    if buffer then
+                        body[#body + 1] = buffer
+                    end
+                until not buffer
+
+                sock:close()
+                ngx.shared.test_dict:set("body", table.concat(body))
+            end
+
+            local ok, err = ngx.timer.at(0, handler, port)
+            if not ok then
+                ngx.say("failed to create timer: ", err)
+                return
+            end
+
+            -- Wait for the timer to finish and store its result.
+            local body
+            for _ = 1, 100 do
+                body = ngx.shared.test_dict:get("body")
+                if body then
+                    break
+                end
+                ngx.sleep(0.01)
+            end
+
+            ngx.say(body)
+        }
+    }
+--- request
+GET /a
+--- response_body
+foo
+--- no_error_log
+[error]
+[warn]
+
+
+
+=== TEST 5: Read a body in a timer context with explicitly provided socket and headers (2 bytes buffer)
+--- http_config eval: $::HttpConfig
+--- config
+    location = /b {
+        content_by_lua_block {
+            ngx.header["Content-Length"] = 3
+            ngx.print("foo")
+        }
+    }
+
+    location = /a {
+        content_by_lua_block {
+            -- ngx.var / ngx.req.* are not available inside a timer, so
+            -- capture what we need and pass it in explicitly.
+            local port = ngx.var.server_port
+
+            local function handler(premature, port)
+                local sock = ngx.socket.tcp()
+                local ok, err = sock:connect("127.0.0.1", port)
+                if not ok then
+                    ngx.shared.test_dict:set("body", "connect failed: " .. err)
+                    return
+                end
+
+                sock:send("GET /b HTTP/1.0\r\nHost: localhost\r\n\r\n")
+
+                -- Read the status line and response headers off the socket.
+                local content_length
+                while true do
+                    local line = sock:receive("*l")
+                    if not line or line == "" then
+                        break
+                    end
+                    local k, v = line:match("^([^:]+):%s*(.+)$")
+                    if k and k:lower() == "content-length" then
+                        content_length = tonumber(v)
+                    end
+                end
+
+                -- Use the explicit socket + headers overloads since
+                -- ngx.req.socket() / ngx.req.get_headers() do not work here.
+                local httpc = require("resty.http").new()
+                local headers = { ["Content-Length"] = content_length }
+                local reader, err = httpc:get_client_body_reader(2, sock, headers)
+                if not reader then
+                    ngx.shared.test_dict:set("body", "no reader: " .. (err or "nil"))
+                    return
+                end
+
+                local body = {}
+                repeat
+                    local buffer, err = reader()
+                    if err then
+                        ngx.shared.test_dict:set("body", "read error: " .. err)
+                        return
+                    end
+                    if buffer then
+                        body[#body + 1] = buffer
+                    end
+                until not buffer
+
+                sock:close()
+                ngx.shared.test_dict:set("body", table.concat(body))
+            end
+
+            local ok, err = ngx.timer.at(0, handler, port)
+            if not ok then
+                ngx.say("failed to create timer: ", err)
+                return
+            end
+
+            -- Wait for the timer to finish and store its result.
+            local body
+            for _ = 1, 100 do
+                body = ngx.shared.test_dict:get("body")
+                if body then
+                    break
+                end
+                ngx.sleep(0.01)
+            end
+
+            ngx.say(body)
+        }
+    }
+--- request
+GET /a
+--- response_body
+foo
+--- no_error_log
+[error]
 [warn]

--- a/t/11-proxy.t
+++ b/t/11-proxy.t
@@ -25,6 +25,7 @@ no_long_string();
 run_tests();
 
 __DATA__
+
 === TEST 1: Proxy GET request and response
 --- http_config eval: $::HttpConfig
 --- config
@@ -61,6 +62,7 @@ X-Test: foo
 [warn]
 --- error_log
 [debug]
+
 
 
 === TEST 2: Proxy POST request and response
@@ -107,6 +109,7 @@ X-Test: foo
 [debug]
 
 
+
 === TEST 3: Proxy multiple headers
 --- http_config eval: $::HttpConfig
 --- config
@@ -142,6 +145,7 @@ OK
 [warn]
 --- error_log
 [debug]
+
 
 
 === TEST 4: Proxy still works with spaces in URI

--- a/t/12-case_insensitive_headers.t
+++ b/t/12-case_insensitive_headers.t
@@ -24,6 +24,7 @@ no_diff();
 run_tests();
 
 __DATA__
+
 === TEST 1: Unit test header normalisation
 --- http_config eval: $::HttpConfig
 --- config
@@ -54,6 +55,7 @@ GET /a
 --- response_body
 --- no_error_log
 [error]
+
 
 
 === TEST 2: Integration test headers normalisation
@@ -89,6 +91,7 @@ bar
 bar
 --- no_error_log
 [error]
+
 
 
 === TEST 3: Integration test request headers normalisation
@@ -129,6 +132,7 @@ bar
 [error]
 
 
+
 === TEST 4: Test that headers remain unique
 --- http_config eval: $::HttpConfig
 --- config
@@ -150,6 +154,7 @@ GET /a
 x-a-header: b
 --- no_error_log
 [error]
+
 
 
 === TEST 5: Prove header tables are always unique

--- a/t/13-default-path.t
+++ b/t/13-default-path.t
@@ -24,6 +24,7 @@ no_long_string();
 run_tests();
 
 __DATA__
+
 === TEST 1: request_uri (check the default path)
 --- http_config eval: $::HttpConfig
 --- config

--- a/t/14-host-header.t
+++ b/t/14-host-header.t
@@ -40,6 +40,7 @@ no_long_string();
 run_tests();
 
 __DATA__
+
 === TEST 1: Default HTTP port is not added to Host header
 --- http_config eval: $::HttpConfig
 --- config
@@ -57,6 +58,7 @@ GET /lua
 [error]
 --- error_log
 Host: www.google.com
+
 
 
 === TEST 2: Default HTTPS port is not added to Host header
@@ -77,6 +79,7 @@ GET /lua
 [error]
 --- error_log
 Host: www.google.com
+
 
 
 === TEST 3: Non-default HTTP port is added to Host header
@@ -103,6 +106,7 @@ GET /lua
 [error]
 --- error_log
 Host: 127.0.0.1:8080
+
 
 
 === TEST 4: Non-default HTTPS port is added to Host header
@@ -139,6 +143,7 @@ GET /lua
 Host: 127.0.0.1:8081
 
 
+
 === TEST 5: No host header on a unix domain socket returns a useful error.
 --- http_config eval: $::HttpConfig
 --- config
@@ -168,6 +173,8 @@ GET /a
 [error]
 --- response_body
 Unable to generate a useful Host header for a unix domain socket. Please provide one.
+
+
 
 === TEST 6: Host header is correct when http_proxy is used
 --- http_config

--- a/t/15-instance-reuse.t
+++ b/t/15-instance-reuse.t
@@ -25,6 +25,7 @@ run_tests();
 
 
 __DATA__
+
 === TEST 1: Reuse an instance connecting on different ports / paths
 --- http_config eval: $::HttpConfig
 --- config
@@ -83,6 +84,7 @@ c
 d
 --- no_error_log
 [error]
+
 
 
 === TEST 2: Reuse input params table

--- a/t/17-deprecated.t
+++ b/t/17-deprecated.t
@@ -24,6 +24,7 @@ no_long_string();
 run_tests();
 
 __DATA__
+
 === TEST 1: Old connect syntax still works
 --- http_config eval: $::HttpConfig
 --- config

--- a/t/18-parse_uri.t
+++ b/t/18-parse_uri.t
@@ -24,6 +24,7 @@ no_long_string();
 run_tests();
 
 __DATA__
+
 === TEST 1: Parse URI errors if malformed
 --- http_config eval: $::HttpConfig
 --- config
@@ -41,6 +42,7 @@ bad uri: http:///example.com
 --- no_error_log
 [error]
 [warn]
+
 
 
 === TEST 2: Parse URI fills in defaults correctly
@@ -81,6 +83,7 @@ scheme: http, host: example.com, port: 80, path: /foo/bar, query: a=1&b=2
 [warn]
 
 
+
 === TEST 3: Parse URI fills in defaults correctly, using backwards compatible mode
 --- http_config eval: $::HttpConfig
 --- config
@@ -117,6 +120,7 @@ scheme: http, host: example.com, port: 80, path: /foo/bar?a=1&b=2
 --- no_error_log
 [error]
 [warn]
+
 
 
 === TEST 4: IPv6 notation

--- a/t/19-ssl_reused_session.t
+++ b/t/19-ssl_reused_session.t
@@ -69,6 +69,7 @@ GET /t
 [alert]
 
 
+
 === TEST 2: ssl_reused_session false does not return session userdata
 --- http_config eval: $::HttpConfig
 --- config
@@ -96,6 +97,7 @@ GET /t
 --- no_error_log
 [error]
 [alert]
+
 
 
 === TEST 3: ssl_reused_session accepts userdata

--- a/t/20-mtls.t
+++ b/t/20-mtls.t
@@ -103,6 +103,7 @@ GET /t
 [warn]
 
 
+
 === TEST 2: Connection fails during handshake with not priv_key
 --- http_config eval: $::mtls_http_config
 --- config eval
@@ -157,6 +158,7 @@ GET /t
 failed to connect: bad ssl_client_priv_key: cdata expected, got string
 --- skip_nginx
 4: < 1.21.4
+
 
 
 === TEST 3: Connection succeeds with client cert and key.
@@ -215,6 +217,8 @@ GET /t
 hello, CN=foo@example.com,O=OpenResty,ST=California,C=US
 --- skip_nginx
 4: < 1.21.4
+
+
 
 === TEST 4: users with different client certs should not share the same pool.
 --- http_config eval: $::mtls_http_config

--- a/t/21-traceparent-header.t
+++ b/t/21-traceparent-header.t
@@ -28,6 +28,7 @@ no_long_string();
 run_tests();
 
 __DATA__
+
 === TEST 1: No traceparent header is set
 --- http_config eval: $::HttpConfig
 --- config
@@ -45,6 +46,7 @@ GET /lua
 --- no_error_log
 [error]
 traceparent:
+
 
 
 === TEST 2: The traceparent header is correctly added when ngx.var.http_traceparent is used
@@ -66,6 +68,7 @@ GET /lua
 [error]
 --- error_log
 traceparent: 00-000000000000000019f4e02c82857913-11488c6e00d1d248-01
+
 
 
 === TEST 3: The traceparent header is not modified from ngx.var.http_traceparent if it is already set


### PR DESCRIPTION
When downloading a big file in a timer, it is unwanted to hold the
whole file in the memory. So write the file to disk piece by piece.