### PR TITLE
feature: docker build: Add `DOCKER_BUILD.md` and `Dockerfile`

### DIFF
--- a/DOCKER_BUILD.md
+++ b/DOCKER_BUILD.md
@@ -1,0 +1,19 @@
+## Build using Docker
+
+Build:
+
+```bash
+docker build -t lua-resty-http-builder:test .
+```
+
+Run:
+
+```bash
+docker run --rm -it -v "$(pwd)":/src -w /src lua-resty-http-builder:test bash
+
+# Check LUA as well as run all tests and coverage:
+luacheck lib && make coverage
+
+# Run a single test file:
+luacheck lib && TEST_FILE=t/01-basic.t make coverage
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM openresty/openresty:1.29.2.4-alpine-fat
+
+RUN apk add --no-cache curl perl bash wget git perl-dev libarchive-tools nodejs; \
+    ln -s /usr/bin/bsdtar /usr/bin/tar
+
+RUN curl -s -L https://cpanmin.us | perl - App::cpanminus > /bin/cpanm && chmod +x /bin/cpanm
+
+RUN cpanm -q -n Test::Nginx
+
+RUN /usr/local/openresty/luajit/bin/luarocks install luacov && \
+    /usr/local/openresty/luajit/bin/luarocks install lua-resty-openssl && \
+    /usr/local/openresty/luajit/bin/luarocks install luacheck


### PR DESCRIPTION
Take the parts from `.github/workflows/test.yml` needed to do full testing with running `luacheck`, the tests, and coverage.

Fix `cpanm` installation by replacing unavailable `http://xrl.us/cpanm` with `https://cpanmin.us | perl - App::cpanminus` as seen at https://perlmaven.com/cpanm.

Fix luarocks dependency by using an OpenResty 1.29.2.4 Docker image. See: https://github.com/ledgetech/lua-resty-http/pull/333

Show all steps needed for interactive development in `DOCKER_BUILD.md`. Also show how to run a single test with `t/01-basic.t` as example.