### PR TITLE
fix: ci: Migrate to cpanminus

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
         ln -s /usr/bin/bsdtar /usr/bin/tar
 
     - name: Install CPAN
-      run: curl -s -L http://xrl.us/cpanm > /bin/cpanm && chmod +x /bin/cpanm
+      run: curl -s -L https://cpanmin.us | perl - App::cpanminus > /bin/cpanm && chmod +x /bin/cpanm
 
     - name: Cache
       uses: actions/cache@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,10 +20,11 @@ jobs:
     strategy:
       matrix:
         openresty_version:
-          - 1.17.8.2
           - 1.19.9.1
-          - 1.21.4.3
-          - 1.25.3.1
+          - 1.21.4.4
+          - 1.25.3.2
+          - 1.27.1.2
+          - 1.29.2.5
 
     runs-on: ubuntu-latest
     container:


### PR DESCRIPTION
Fix cpanm installation by replacing unavailable `http://xrl.us/cpanm` with `https://cpanmin.us | perl - App::cpanminus` as seen at https://perlmaven.com/cpanm.