### PR TITLE
feat: Add OpenResty 1.31.1.1 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,7 @@ jobs:
           - 1.25.3.2
           - 1.27.1.2
           - 1.29.2.5
+          - 1.31.1.1
 
     runs-on: ubuntu-latest
     container:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openresty/openresty:1.29.2.4-alpine-fat
+FROM openresty/openresty:1.31.1.1-alpine-fat
 
 RUN apk add --no-cache curl perl bash wget git perl-dev libarchive-tools nodejs; \
     ln -s /usr/bin/bsdtar /usr/bin/tar


### PR DESCRIPTION
Add OpenResty 1.31.1.1 image to local Docker build and GitHub actions workflow.